### PR TITLE
 Install git to the base images for devices.

### DIFF
--- a/device-base/Dockerfile.alpine.i386.edison.tpl
+++ b/device-base/Dockerfile.alpine.i386.edison.tpl
@@ -8,6 +8,7 @@ RUN apk add --update \
 		net-tools \			
 		ifupdown \				
 		usbutils \
+		git \
 	&& rm -rf /var/cache/apk/*
 
 # MRAA commit
@@ -18,7 +19,6 @@ RUN set -x \
 	&& buildDeps=' \
 		build-base \
 		cmake \
-		git \
 		libpcrecpp \
 		libpcre32 \
 		python-dev \

--- a/device-base/Dockerfile.alpine.rpi.tpl
+++ b/device-base/Dockerfile.alpine.rpi.tpl
@@ -9,6 +9,7 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 		raspberrypi \
 		raspberrypi-libs \
 		raspberrypi-dev \

--- a/device-base/Dockerfile.alpine.tpl
+++ b/device-base/Dockerfile.alpine.tpl
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/Dockerfile.armv7hf.bbb.tpl
+++ b/device-base/Dockerfile.armv7hf.bbb.tpl
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/Dockerfile.armv7hf.rpi.tpl
+++ b/device-base/Dockerfile.armv7hf.rpi.tpl
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \
 		iputils-ping \
 		i2c-tools \

--- a/device-base/Dockerfile.artik.fedora.tpl
+++ b/device-base/Dockerfile.artik.fedora.tpl
@@ -11,6 +11,7 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 		libartik-sdk-tests \
 		libartik-sdk-zigbee-devel \

--- a/device-base/Dockerfile.fedora.tpl
+++ b/device-base/Dockerfile.fedora.tpl
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/Dockerfile.i386.edison.tpl
+++ b/device-base/Dockerfile.i386.edison.tpl
@@ -6,11 +6,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \
 		kmod \
 		nano \
-		net-tools \		
+		net-tools \
 		i2c-tools \
-		iputils-ping \		
-		ifupdown \				
-		usbutils \		
+		iputils-ping \
+		ifupdown \
+		git \
+		usbutils \
 	&& rm -rf /var/lib/apt/lists/*
 
 # MRAA
@@ -24,7 +25,6 @@ ENV UPM_VERSION #{UPM_VERSION}
 RUN set -x \
 	&& buildDeps=' \
 		build-essential \
-		git-core \
 		libpcre3-dev \
 		python-dev \
 		swig \

--- a/device-base/Dockerfile.tpl
+++ b/device-base/Dockerfile.tpl
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/am571x-evm/alpine/3.5/Dockerfile
+++ b/device-base/am571x-evm/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/am571x-evm/alpine/3.6/Dockerfile
+++ b/device-base/am571x-evm/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/am571x-evm/debian/buster/Dockerfile
+++ b/device-base/am571x-evm/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/am571x-evm/debian/jessie/Dockerfile
+++ b/device-base/am571x-evm/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/am571x-evm/debian/stretch/Dockerfile
+++ b/device-base/am571x-evm/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/am571x-evm/debian/wheezy/Dockerfile
+++ b/device-base/am571x-evm/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/am571x-evm/fedora/24/Dockerfile
+++ b/device-base/am571x-evm/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/am571x-evm/fedora/25/Dockerfile
+++ b/device-base/am571x-evm/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/am571x-evm/fedora/26/Dockerfile
+++ b/device-base/am571x-evm/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/apalis-imx6q/alpine/3.5/Dockerfile
+++ b/device-base/apalis-imx6q/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/apalis-imx6q/alpine/3.6/Dockerfile
+++ b/device-base/apalis-imx6q/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/apalis-imx6q/debian/buster/Dockerfile
+++ b/device-base/apalis-imx6q/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/apalis-imx6q/debian/jessie/Dockerfile
+++ b/device-base/apalis-imx6q/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/apalis-imx6q/debian/stretch/Dockerfile
+++ b/device-base/apalis-imx6q/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/apalis-imx6q/debian/wheezy/Dockerfile
+++ b/device-base/apalis-imx6q/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/apalis-imx6q/fedora/24/Dockerfile
+++ b/device-base/apalis-imx6q/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/apalis-imx6q/fedora/25/Dockerfile
+++ b/device-base/apalis-imx6q/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/apalis-imx6q/fedora/26/Dockerfile
+++ b/device-base/apalis-imx6q/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/artik10/alpine/3.5/Dockerfile
+++ b/device-base/artik10/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/artik10/alpine/3.6/Dockerfile
+++ b/device-base/artik10/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/artik10/debian/buster/Dockerfile
+++ b/device-base/artik10/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik10/debian/jessie/Dockerfile
+++ b/device-base/artik10/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik10/debian/stretch/Dockerfile
+++ b/device-base/artik10/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik10/debian/wheezy/Dockerfile
+++ b/device-base/artik10/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik10/fedora/24/Dockerfile
+++ b/device-base/artik10/fedora/24/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 		libartik-sdk-tests \
 		libartik-sdk-zigbee-devel \

--- a/device-base/artik10/fedora/25/Dockerfile
+++ b/device-base/artik10/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/artik10/fedora/26/Dockerfile
+++ b/device-base/artik10/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/artik5/alpine/3.5/Dockerfile
+++ b/device-base/artik5/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/artik5/alpine/3.6/Dockerfile
+++ b/device-base/artik5/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/artik5/debian/buster/Dockerfile
+++ b/device-base/artik5/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik5/debian/jessie/Dockerfile
+++ b/device-base/artik5/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik5/debian/stretch/Dockerfile
+++ b/device-base/artik5/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik5/debian/wheezy/Dockerfile
+++ b/device-base/artik5/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik5/fedora/24/Dockerfile
+++ b/device-base/artik5/fedora/24/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 		libartik-sdk-tests \
 		libartik-sdk-zigbee-devel \

--- a/device-base/artik5/fedora/25/Dockerfile
+++ b/device-base/artik5/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/artik5/fedora/26/Dockerfile
+++ b/device-base/artik5/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/artik710/alpine/3.5/Dockerfile
+++ b/device-base/artik710/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/artik710/alpine/3.6/Dockerfile
+++ b/device-base/artik710/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/artik710/debian/buster/Dockerfile
+++ b/device-base/artik710/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik710/debian/jessie/Dockerfile
+++ b/device-base/artik710/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik710/debian/stretch/Dockerfile
+++ b/device-base/artik710/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik710/debian/wheezy/Dockerfile
+++ b/device-base/artik710/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/artik710/fedora/24/Dockerfile
+++ b/device-base/artik710/fedora/24/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 		libartik-sdk-tests \
 		libartik-sdk-zigbee-devel \

--- a/device-base/artik710/fedora/25/Dockerfile
+++ b/device-base/artik710/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/artik710/fedora/26/Dockerfile
+++ b/device-base/artik710/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/beaglebone-black/alpine/3.5/Dockerfile
+++ b/device-base/beaglebone-black/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/beaglebone-black/alpine/3.6/Dockerfile
+++ b/device-base/beaglebone-black/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/beaglebone-black/debian/buster/Dockerfile
+++ b/device-base/beaglebone-black/debian/buster/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-black/debian/jessie/Dockerfile
+++ b/device-base/beaglebone-black/debian/jessie/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-black/debian/stretch/Dockerfile
+++ b/device-base/beaglebone-black/debian/stretch/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-black/debian/wheezy/Dockerfile
+++ b/device-base/beaglebone-black/debian/wheezy/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-black/fedora/24/Dockerfile
+++ b/device-base/beaglebone-black/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/beaglebone-black/fedora/25/Dockerfile
+++ b/device-base/beaglebone-black/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/beaglebone-black/fedora/26/Dockerfile
+++ b/device-base/beaglebone-black/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/beaglebone-green-wifi/alpine/3.5/Dockerfile
+++ b/device-base/beaglebone-green-wifi/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/beaglebone-green-wifi/alpine/3.6/Dockerfile
+++ b/device-base/beaglebone-green-wifi/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/beaglebone-green-wifi/debian/buster/Dockerfile
+++ b/device-base/beaglebone-green-wifi/debian/buster/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-green-wifi/debian/jessie/Dockerfile
+++ b/device-base/beaglebone-green-wifi/debian/jessie/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-green-wifi/debian/stretch/Dockerfile
+++ b/device-base/beaglebone-green-wifi/debian/stretch/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-green-wifi/debian/wheezy/Dockerfile
+++ b/device-base/beaglebone-green-wifi/debian/wheezy/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-green-wifi/fedora/24/Dockerfile
+++ b/device-base/beaglebone-green-wifi/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/beaglebone-green-wifi/fedora/25/Dockerfile
+++ b/device-base/beaglebone-green-wifi/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/beaglebone-green-wifi/fedora/26/Dockerfile
+++ b/device-base/beaglebone-green-wifi/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/beaglebone-green/alpine/3.5/Dockerfile
+++ b/device-base/beaglebone-green/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/beaglebone-green/alpine/3.6/Dockerfile
+++ b/device-base/beaglebone-green/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/beaglebone-green/debian/buster/Dockerfile
+++ b/device-base/beaglebone-green/debian/buster/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-green/debian/jessie/Dockerfile
+++ b/device-base/beaglebone-green/debian/jessie/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-green/debian/stretch/Dockerfile
+++ b/device-base/beaglebone-green/debian/stretch/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-green/debian/wheezy/Dockerfile
+++ b/device-base/beaglebone-green/debian/wheezy/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \

--- a/device-base/beaglebone-green/fedora/24/Dockerfile
+++ b/device-base/beaglebone-green/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/beaglebone-green/fedora/25/Dockerfile
+++ b/device-base/beaglebone-green/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/beaglebone-green/fedora/26/Dockerfile
+++ b/device-base/beaglebone-green/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/colibri-imx6dl/alpine/3.5/Dockerfile
+++ b/device-base/colibri-imx6dl/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/colibri-imx6dl/alpine/3.6/Dockerfile
+++ b/device-base/colibri-imx6dl/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/colibri-imx6dl/debian/buster/Dockerfile
+++ b/device-base/colibri-imx6dl/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/colibri-imx6dl/debian/jessie/Dockerfile
+++ b/device-base/colibri-imx6dl/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/colibri-imx6dl/debian/stretch/Dockerfile
+++ b/device-base/colibri-imx6dl/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/colibri-imx6dl/debian/wheezy/Dockerfile
+++ b/device-base/colibri-imx6dl/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/colibri-imx6dl/fedora/24/Dockerfile
+++ b/device-base/colibri-imx6dl/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/colibri-imx6dl/fedora/25/Dockerfile
+++ b/device-base/colibri-imx6dl/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/colibri-imx6dl/fedora/26/Dockerfile
+++ b/device-base/colibri-imx6dl/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/cybertan-ze250/alpine/3.5/Dockerfile
+++ b/device-base/cybertan-ze250/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/cybertan-ze250/alpine/3.6/Dockerfile
+++ b/device-base/cybertan-ze250/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/cybertan-ze250/debian/buster/Dockerfile
+++ b/device-base/cybertan-ze250/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/cybertan-ze250/debian/jessie/Dockerfile
+++ b/device-base/cybertan-ze250/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/cybertan-ze250/debian/stretch/Dockerfile
+++ b/device-base/cybertan-ze250/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/cybertan-ze250/debian/wheezy/Dockerfile
+++ b/device-base/cybertan-ze250/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/hummingboard/alpine/3.5/Dockerfile
+++ b/device-base/hummingboard/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/hummingboard/alpine/3.6/Dockerfile
+++ b/device-base/hummingboard/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/hummingboard/debian/buster/Dockerfile
+++ b/device-base/hummingboard/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/hummingboard/debian/jessie/Dockerfile
+++ b/device-base/hummingboard/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/hummingboard/debian/stretch/Dockerfile
+++ b/device-base/hummingboard/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/hummingboard/debian/wheezy/Dockerfile
+++ b/device-base/hummingboard/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/hummingboard/fedora/24/Dockerfile
+++ b/device-base/hummingboard/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/hummingboard/fedora/25/Dockerfile
+++ b/device-base/hummingboard/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/hummingboard/fedora/26/Dockerfile
+++ b/device-base/hummingboard/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/imx6ul-var-dart/alpine/3.5/Dockerfile
+++ b/device-base/imx6ul-var-dart/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/imx6ul-var-dart/alpine/3.6/Dockerfile
+++ b/device-base/imx6ul-var-dart/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/imx6ul-var-dart/debian/buster/Dockerfile
+++ b/device-base/imx6ul-var-dart/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/imx6ul-var-dart/debian/jessie/Dockerfile
+++ b/device-base/imx6ul-var-dart/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/imx6ul-var-dart/debian/stretch/Dockerfile
+++ b/device-base/imx6ul-var-dart/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/imx6ul-var-dart/debian/wheezy/Dockerfile
+++ b/device-base/imx6ul-var-dart/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/imx6ul-var-dart/fedora/24/Dockerfile
+++ b/device-base/imx6ul-var-dart/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/imx6ul-var-dart/fedora/25/Dockerfile
+++ b/device-base/imx6ul-var-dart/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/imx6ul-var-dart/fedora/26/Dockerfile
+++ b/device-base/imx6ul-var-dart/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/intel-edison/alpine/3.5/Dockerfile
+++ b/device-base/intel-edison/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/intel-edison/alpine/3.6/Dockerfile
+++ b/device-base/intel-edison/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/intel-edison/debian/buster/Dockerfile
+++ b/device-base/intel-edison/debian/buster/Dockerfile
@@ -6,11 +6,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \
 		kmod \
 		nano \
-		net-tools \		
+		net-tools \
 		i2c-tools \
-		iputils-ping \		
-		ifupdown \				
-		usbutils \		
+		iputils-ping \
+		ifupdown \
+		git \
+		usbutils \
 	&& rm -rf /var/lib/apt/lists/*
 
 # MRAA
@@ -24,7 +25,6 @@ ENV UPM_VERSION b9010059ade9b3ee9fb343b23c506acaed7d0b15
 RUN set -x \
 	&& buildDeps=' \
 		build-essential \
-		git-core \
 		libpcre3-dev \
 		python-dev \
 		swig \

--- a/device-base/intel-edison/debian/jessie/Dockerfile
+++ b/device-base/intel-edison/debian/jessie/Dockerfile
@@ -6,11 +6,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \
 		kmod \
 		nano \
-		net-tools \		
+		net-tools \
 		i2c-tools \
-		iputils-ping \		
-		ifupdown \				
-		usbutils \		
+		iputils-ping \
+		ifupdown \
+		git \
+		usbutils \
 	&& rm -rf /var/lib/apt/lists/*
 
 # MRAA
@@ -24,7 +25,6 @@ ENV UPM_VERSION b9010059ade9b3ee9fb343b23c506acaed7d0b15
 RUN set -x \
 	&& buildDeps=' \
 		build-essential \
-		git-core \
 		libpcre3-dev \
 		python-dev \
 		swig \

--- a/device-base/intel-edison/debian/stretch/Dockerfile
+++ b/device-base/intel-edison/debian/stretch/Dockerfile
@@ -6,11 +6,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \
 		kmod \
 		nano \
-		net-tools \		
+		net-tools \
 		i2c-tools \
-		iputils-ping \		
-		ifupdown \				
-		usbutils \		
+		iputils-ping \
+		ifupdown \
+		git \
+		usbutils \
 	&& rm -rf /var/lib/apt/lists/*
 
 # MRAA
@@ -24,7 +25,6 @@ ENV UPM_VERSION b9010059ade9b3ee9fb343b23c506acaed7d0b15
 RUN set -x \
 	&& buildDeps=' \
 		build-essential \
-		git-core \
 		libpcre3-dev \
 		python-dev \
 		swig \

--- a/device-base/intel-edison/debian/wheezy/Dockerfile
+++ b/device-base/intel-edison/debian/wheezy/Dockerfile
@@ -6,11 +6,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \
 		kmod \
 		nano \
-		net-tools \		
+		net-tools \
 		i2c-tools \
-		iputils-ping \		
-		ifupdown \				
-		usbutils \		
+		iputils-ping \
+		ifupdown \
+		git \
+		usbutils \
 	&& rm -rf /var/lib/apt/lists/*
 
 # MRAA
@@ -24,7 +25,6 @@ ENV UPM_VERSION b9010059ade9b3ee9fb343b23c506acaed7d0b15
 RUN set -x \
 	&& buildDeps=' \
 		build-essential \
-		git-core \
 		libpcre3-dev \
 		python-dev \
 		swig \

--- a/device-base/intel-nuc/alpine/3.5/Dockerfile
+++ b/device-base/intel-nuc/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/intel-nuc/alpine/3.6/Dockerfile
+++ b/device-base/intel-nuc/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/intel-nuc/debian/buster/Dockerfile
+++ b/device-base/intel-nuc/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/intel-nuc/debian/jessie/Dockerfile
+++ b/device-base/intel-nuc/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/intel-nuc/debian/stretch/Dockerfile
+++ b/device-base/intel-nuc/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/intel-nuc/debian/wheezy/Dockerfile
+++ b/device-base/intel-nuc/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/intel-nuc/fedora/24/Dockerfile
+++ b/device-base/intel-nuc/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/intel-nuc/fedora/25/Dockerfile
+++ b/device-base/intel-nuc/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/intel-nuc/fedora/26/Dockerfile
+++ b/device-base/intel-nuc/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/iot2000/alpine/3.5/Dockerfile
+++ b/device-base/iot2000/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/iot2000/alpine/3.6/Dockerfile
+++ b/device-base/iot2000/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/iot2000/debian/buster/Dockerfile
+++ b/device-base/iot2000/debian/buster/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*
 RUN set -x \

--- a/device-base/iot2000/debian/jessie/Dockerfile
+++ b/device-base/iot2000/debian/jessie/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*
 RUN set -x \

--- a/device-base/iot2000/debian/stretch/Dockerfile
+++ b/device-base/iot2000/debian/stretch/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*
 RUN set -x \

--- a/device-base/iot2000/debian/wheezy/Dockerfile
+++ b/device-base/iot2000/debian/wheezy/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*
 RUN set -x \

--- a/device-base/jetson-tx2/alpine/3.5/Dockerfile
+++ b/device-base/jetson-tx2/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/jetson-tx2/alpine/3.6/Dockerfile
+++ b/device-base/jetson-tx2/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/jetson-tx2/debian/buster/Dockerfile
+++ b/device-base/jetson-tx2/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/jetson-tx2/debian/jessie/Dockerfile
+++ b/device-base/jetson-tx2/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/jetson-tx2/debian/stretch/Dockerfile
+++ b/device-base/jetson-tx2/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/jetson-tx2/debian/wheezy/Dockerfile
+++ b/device-base/jetson-tx2/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/jetson-tx2/fedora/24/Dockerfile
+++ b/device-base/jetson-tx2/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/jetson-tx2/fedora/25/Dockerfile
+++ b/device-base/jetson-tx2/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/jetson-tx2/fedora/26/Dockerfile
+++ b/device-base/jetson-tx2/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/kitra520/alpine/3.5/Dockerfile
+++ b/device-base/kitra520/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/kitra520/alpine/3.6/Dockerfile
+++ b/device-base/kitra520/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/kitra520/debian/buster/Dockerfile
+++ b/device-base/kitra520/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/kitra520/debian/jessie/Dockerfile
+++ b/device-base/kitra520/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/kitra520/debian/stretch/Dockerfile
+++ b/device-base/kitra520/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/kitra520/debian/wheezy/Dockerfile
+++ b/device-base/kitra520/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/kitra520/fedora/24/Dockerfile
+++ b/device-base/kitra520/fedora/24/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 		libartik-sdk-tests \
 		libartik-sdk-zigbee-devel \

--- a/device-base/kitra520/fedora/25/Dockerfile
+++ b/device-base/kitra520/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/kitra520/fedora/26/Dockerfile
+++ b/device-base/kitra520/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/kitra710/alpine/3.5/Dockerfile
+++ b/device-base/kitra710/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/kitra710/alpine/3.6/Dockerfile
+++ b/device-base/kitra710/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/kitra710/debian/buster/Dockerfile
+++ b/device-base/kitra710/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/kitra710/debian/jessie/Dockerfile
+++ b/device-base/kitra710/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/kitra710/debian/stretch/Dockerfile
+++ b/device-base/kitra710/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/kitra710/debian/wheezy/Dockerfile
+++ b/device-base/kitra710/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/kitra710/fedora/24/Dockerfile
+++ b/device-base/kitra710/fedora/24/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 		libartik-sdk-tests \
 		libartik-sdk-zigbee-devel \

--- a/device-base/kitra710/fedora/25/Dockerfile
+++ b/device-base/kitra710/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/kitra710/fedora/26/Dockerfile
+++ b/device-base/kitra710/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/nitrogen6x/alpine/3.5/Dockerfile
+++ b/device-base/nitrogen6x/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/nitrogen6x/alpine/3.6/Dockerfile
+++ b/device-base/nitrogen6x/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/nitrogen6x/debian/buster/Dockerfile
+++ b/device-base/nitrogen6x/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/nitrogen6x/debian/jessie/Dockerfile
+++ b/device-base/nitrogen6x/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/nitrogen6x/debian/stretch/Dockerfile
+++ b/device-base/nitrogen6x/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/nitrogen6x/debian/wheezy/Dockerfile
+++ b/device-base/nitrogen6x/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/nitrogen6x/fedora/24/Dockerfile
+++ b/device-base/nitrogen6x/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/nitrogen6x/fedora/25/Dockerfile
+++ b/device-base/nitrogen6x/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/nitrogen6x/fedora/26/Dockerfile
+++ b/device-base/nitrogen6x/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/odroid-c1/alpine/3.5/Dockerfile
+++ b/device-base/odroid-c1/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/odroid-c1/alpine/3.6/Dockerfile
+++ b/device-base/odroid-c1/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/odroid-c1/debian/buster/Dockerfile
+++ b/device-base/odroid-c1/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/odroid-c1/debian/jessie/Dockerfile
+++ b/device-base/odroid-c1/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/odroid-c1/debian/stretch/Dockerfile
+++ b/device-base/odroid-c1/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/odroid-c1/debian/wheezy/Dockerfile
+++ b/device-base/odroid-c1/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/odroid-c1/fedora/24/Dockerfile
+++ b/device-base/odroid-c1/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/odroid-c1/fedora/25/Dockerfile
+++ b/device-base/odroid-c1/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/odroid-c1/fedora/26/Dockerfile
+++ b/device-base/odroid-c1/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/odroid-xu4/alpine/3.5/Dockerfile
+++ b/device-base/odroid-xu4/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/odroid-xu4/alpine/3.6/Dockerfile
+++ b/device-base/odroid-xu4/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/odroid-xu4/debian/buster/Dockerfile
+++ b/device-base/odroid-xu4/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/odroid-xu4/debian/jessie/Dockerfile
+++ b/device-base/odroid-xu4/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/odroid-xu4/debian/stretch/Dockerfile
+++ b/device-base/odroid-xu4/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/odroid-xu4/debian/wheezy/Dockerfile
+++ b/device-base/odroid-xu4/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/odroid-xu4/fedora/24/Dockerfile
+++ b/device-base/odroid-xu4/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/odroid-xu4/fedora/25/Dockerfile
+++ b/device-base/odroid-xu4/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/odroid-xu4/fedora/26/Dockerfile
+++ b/device-base/odroid-xu4/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/parallella/alpine/3.5/Dockerfile
+++ b/device-base/parallella/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/parallella/alpine/3.6/Dockerfile
+++ b/device-base/parallella/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/parallella/debian/buster/Dockerfile
+++ b/device-base/parallella/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/parallella/debian/jessie/Dockerfile
+++ b/device-base/parallella/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/parallella/debian/stretch/Dockerfile
+++ b/device-base/parallella/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/parallella/debian/wheezy/Dockerfile
+++ b/device-base/parallella/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/parallella/fedora/24/Dockerfile
+++ b/device-base/parallella/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/parallella/fedora/25/Dockerfile
+++ b/device-base/parallella/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/parallella/fedora/26/Dockerfile
+++ b/device-base/parallella/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/qemux86-64/alpine/3.5/Dockerfile
+++ b/device-base/qemux86-64/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/qemux86-64/alpine/3.6/Dockerfile
+++ b/device-base/qemux86-64/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/qemux86-64/debian/buster/Dockerfile
+++ b/device-base/qemux86-64/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/qemux86-64/debian/jessie/Dockerfile
+++ b/device-base/qemux86-64/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/qemux86-64/debian/stretch/Dockerfile
+++ b/device-base/qemux86-64/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/qemux86-64/debian/wheezy/Dockerfile
+++ b/device-base/qemux86-64/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/qemux86-64/fedora/24/Dockerfile
+++ b/device-base/qemux86-64/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/qemux86-64/fedora/25/Dockerfile
+++ b/device-base/qemux86-64/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/qemux86-64/fedora/26/Dockerfile
+++ b/device-base/qemux86-64/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/qemux86/alpine/3.5/Dockerfile
+++ b/device-base/qemux86/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/qemux86/alpine/3.6/Dockerfile
+++ b/device-base/qemux86/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/qemux86/debian/buster/Dockerfile
+++ b/device-base/qemux86/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/qemux86/debian/jessie/Dockerfile
+++ b/device-base/qemux86/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/qemux86/debian/stretch/Dockerfile
+++ b/device-base/qemux86/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/qemux86/debian/wheezy/Dockerfile
+++ b/device-base/qemux86/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/raspberry-pi/alpine/3.5/Dockerfile
+++ b/device-base/raspberry-pi/alpine/3.5/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 		raspberrypi \
 		raspberrypi-libs \
 		raspberrypi-dev \

--- a/device-base/raspberry-pi/alpine/3.6/Dockerfile
+++ b/device-base/raspberry-pi/alpine/3.6/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 		raspberrypi \
 		raspberrypi-libs \
 		raspberrypi-dev \

--- a/device-base/raspberry-pi2/alpine/3.5/Dockerfile
+++ b/device-base/raspberry-pi2/alpine/3.5/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 		raspberrypi \
 		raspberrypi-libs \
 		raspberrypi-dev \

--- a/device-base/raspberry-pi2/alpine/3.6/Dockerfile
+++ b/device-base/raspberry-pi2/alpine/3.6/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 		raspberrypi \
 		raspberrypi-libs \
 		raspberrypi-dev \

--- a/device-base/raspberry-pi2/debian/buster/Dockerfile
+++ b/device-base/raspberry-pi2/debian/buster/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \
 		iputils-ping \
 		i2c-tools \

--- a/device-base/raspberry-pi2/debian/jessie/Dockerfile
+++ b/device-base/raspberry-pi2/debian/jessie/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \
 		iputils-ping \
 		i2c-tools \

--- a/device-base/raspberry-pi2/debian/stretch/Dockerfile
+++ b/device-base/raspberry-pi2/debian/stretch/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \
 		iputils-ping \
 		i2c-tools \

--- a/device-base/raspberry-pi2/debian/wheezy/Dockerfile
+++ b/device-base/raspberry-pi2/debian/wheezy/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \
 		iputils-ping \
 		i2c-tools \

--- a/device-base/raspberry-pi2/fedora/24/Dockerfile
+++ b/device-base/raspberry-pi2/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/raspberry-pi2/fedora/25/Dockerfile
+++ b/device-base/raspberry-pi2/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/raspberry-pi2/fedora/26/Dockerfile
+++ b/device-base/raspberry-pi2/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/raspberrypi3/alpine/3.5/Dockerfile
+++ b/device-base/raspberrypi3/alpine/3.5/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 		raspberrypi \
 		raspberrypi-libs \
 		raspberrypi-dev \

--- a/device-base/raspberrypi3/alpine/3.6/Dockerfile
+++ b/device-base/raspberrypi3/alpine/3.6/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 		raspberrypi \
 		raspberrypi-libs \
 		raspberrypi-dev \

--- a/device-base/raspberrypi3/debian/buster/Dockerfile
+++ b/device-base/raspberrypi3/debian/buster/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \
 		iputils-ping \
 		i2c-tools \

--- a/device-base/raspberrypi3/debian/jessie/Dockerfile
+++ b/device-base/raspberrypi3/debian/jessie/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \
 		iputils-ping \
 		i2c-tools \

--- a/device-base/raspberrypi3/debian/stretch/Dockerfile
+++ b/device-base/raspberrypi3/debian/stretch/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \
 		iputils-ping \
 		i2c-tools \

--- a/device-base/raspberrypi3/debian/wheezy/Dockerfile
+++ b/device-base/raspberrypi3/debian/wheezy/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		kmod \
 		nano \
 		net-tools \
+		git \
 		ifupdown \
 		iputils-ping \
 		i2c-tools \

--- a/device-base/raspberrypi3/fedora/24/Dockerfile
+++ b/device-base/raspberrypi3/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/raspberrypi3/fedora/25/Dockerfile
+++ b/device-base/raspberrypi3/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/raspberrypi3/fedora/26/Dockerfile
+++ b/device-base/raspberrypi3/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/ts4900/alpine/3.5/Dockerfile
+++ b/device-base/ts4900/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/ts4900/alpine/3.6/Dockerfile
+++ b/device-base/ts4900/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/ts4900/debian/buster/Dockerfile
+++ b/device-base/ts4900/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/ts4900/debian/jessie/Dockerfile
+++ b/device-base/ts4900/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/ts4900/debian/stretch/Dockerfile
+++ b/device-base/ts4900/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/ts4900/debian/wheezy/Dockerfile
+++ b/device-base/ts4900/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/ts4900/fedora/24/Dockerfile
+++ b/device-base/ts4900/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/ts4900/fedora/25/Dockerfile
+++ b/device-base/ts4900/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/ts4900/fedora/26/Dockerfile
+++ b/device-base/ts4900/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/ts7700/debian/buster/Dockerfile
+++ b/device-base/ts7700/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/ts7700/debian/jessie/Dockerfile
+++ b/device-base/ts7700/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/ts7700/debian/stretch/Dockerfile
+++ b/device-base/ts7700/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/ts7700/debian/wheezy/Dockerfile
+++ b/device-base/ts7700/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/up-board/alpine/3.5/Dockerfile
+++ b/device-base/up-board/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/up-board/alpine/3.6/Dockerfile
+++ b/device-base/up-board/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/up-board/debian/buster/Dockerfile
+++ b/device-base/up-board/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/up-board/debian/jessie/Dockerfile
+++ b/device-base/up-board/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/up-board/debian/stretch/Dockerfile
+++ b/device-base/up-board/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/up-board/debian/wheezy/Dockerfile
+++ b/device-base/up-board/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/up-board/fedora/24/Dockerfile
+++ b/device-base/up-board/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/up-board/fedora/25/Dockerfile
+++ b/device-base/up-board/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/up-board/fedora/26/Dockerfile
+++ b/device-base/up-board/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/via-vab820-quad/alpine/3.5/Dockerfile
+++ b/device-base/via-vab820-quad/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/via-vab820-quad/alpine/3.6/Dockerfile
+++ b/device-base/via-vab820-quad/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/via-vab820-quad/debian/buster/Dockerfile
+++ b/device-base/via-vab820-quad/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/via-vab820-quad/debian/jessie/Dockerfile
+++ b/device-base/via-vab820-quad/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/via-vab820-quad/debian/stretch/Dockerfile
+++ b/device-base/via-vab820-quad/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/via-vab820-quad/debian/wheezy/Dockerfile
+++ b/device-base/via-vab820-quad/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/via-vab820-quad/fedora/24/Dockerfile
+++ b/device-base/via-vab820-quad/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/via-vab820-quad/fedora/25/Dockerfile
+++ b/device-base/via-vab820-quad/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/via-vab820-quad/fedora/26/Dockerfile
+++ b/device-base/via-vab820-quad/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/zc702-zynq7/alpine/3.5/Dockerfile
+++ b/device-base/zc702-zynq7/alpine/3.5/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/zc702-zynq7/alpine/3.6/Dockerfile
+++ b/device-base/zc702-zynq7/alpine/3.6/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --update \
 		ifupdown \		
 		usbutils \
 		gnupg \
+		git \
 	&& rm -rf /var/cache/apk/*

--- a/device-base/zc702-zynq7/debian/buster/Dockerfile
+++ b/device-base/zc702-zynq7/debian/buster/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/zc702-zynq7/debian/jessie/Dockerfile
+++ b/device-base/zc702-zynq7/debian/jessie/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/zc702-zynq7/debian/stretch/Dockerfile
+++ b/device-base/zc702-zynq7/debian/stretch/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/zc702-zynq7/debian/wheezy/Dockerfile
+++ b/device-base/zc702-zynq7/debian/wheezy/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ifupdown \	
 		iputils-ping \	
 		i2c-tools \
+		git \
 		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*

--- a/device-base/zc702-zynq7/fedora/24/Dockerfile
+++ b/device-base/zc702-zynq7/fedora/24/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/zc702-zynq7/fedora/25/Dockerfile
+++ b/device-base/zc702-zynq7/fedora/25/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all

--- a/device-base/zc702-zynq7/fedora/26/Dockerfile
+++ b/device-base/zc702-zynq7/fedora/26/Dockerfile
@@ -8,5 +8,6 @@ RUN dnf install -y \
 		net-tools \
 		usbutils \
 		gnupg \
+		git-core \
 		i2c-tools \
 	&& dnf clean all


### PR DESCRIPTION
There are cases when users use `-slim` variant images have their builds broken because of git is missing. Also some tools like (pip) use git as well so essential package like git should be installed in the base images for devices.