### PR TITLE
udev: Change how UDEV env var works

### DIFF
--- a/scripts/assets/entry-alpine.sh
+++ b/scripts/assets/entry-alpine.sh
@@ -1,18 +1,51 @@
 #!/bin/bash
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
+function mount_dev()
+{
+	mkdir -p /tmp
+	mount -t devtmpfs none /tmp
+	mkdir -p /tmp/shm
+	mount --move /dev/shm /tmp/shm
+	mkdir -p /tmp/mqueue
+	mount --move /dev/mqueue /tmp/mqueue
+	mkdir -p /tmp/pts
+	mount --move /dev/pts /tmp/pts
+	touch /tmp/console
+	mount --move /dev/console /tmp/console
+	umount /dev || true
+	mount --move /tmp /dev
+
+	# Since the devpts is mounted with -o newinstance by Docker, we need to make
+	# /dev/ptmx point to its ptmx.
+	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+	ln -sf /dev/pts/ptmx /dev/ptmx
+	mount -t debugfs nodev /sys/kernel/debug
+}
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
-		udevd --daemon &> /dev/null
-		udevadm trigger &> /dev/null
+		if $PRIVILEGED; then
+			mount_dev
+			unshare --net udevd --daemon &> /dev/null
+			udevadm trigger &> /dev/null
+		else
+			echo "Unable to start udev, container must be run in privileged mode to start udev!"
+		fi
 	fi
 }
 
 function init()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec "$CMD" "$@"
 	else

--- a/scripts/assets/entry.sh
+++ b/scripts/assets/entry.sh
@@ -1,23 +1,55 @@
 #!/bin/bash
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
+function mount_dev()
+{
+	mkdir -p /tmp
+	mount -t devtmpfs none /tmp
+	mkdir -p /tmp/shm
+	mount --move /dev/shm /tmp/shm
+	mkdir -p /tmp/mqueue
+	mount --move /dev/mqueue /tmp/mqueue
+	mkdir -p /tmp/pts
+	mount --move /dev/pts /tmp/pts
+	touch /tmp/console
+	mount --move /dev/console /tmp/console
+	umount /dev || true
+	mount --move /tmp /dev
+
+	# Since the devpts is mounted with -o newinstance by Docker, we need to make
+	# /dev/ptmx point to its ptmx.
+	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+	ln -sf /dev/pts/ptmx /dev/ptmx
+	mount -t debugfs nodev /sys/kernel/debug
+}
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
-		which udevd
-		if [ $? == '0' ]; then
-			udevd --daemon &> /dev/null
+		if $PRIVILEGED; then
+			mount_dev
+			if command -v udevd &>/dev/null; then
+				unshare --net udevd --daemon &> /dev/null
+			else
+				unshare --net /lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
 		else
-			/lib/systemd/systemd-udevd --daemon &> /dev/null
+			echo "Unable to start udev, container must be run in privileged mode to start udev!"
 		fi
-		udevadm trigger &> /dev/null
 	fi
 }
 
 function init()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec "$CMD" "$@"
 	else


### PR DESCRIPTION
If Udev is set, check if current container is in privileged mode, if yes then mount devtmpfs and run udev, if no then a warning is printed.

Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>