### PR TITLE
Revert "blueprint: Add onbuild partial to output base image features"

### DIFF
--- a/scripts/blueprints/os-arch.yaml
+++ b/scripts/blueprints/os-arch.yaml
@@ -33,9 +33,6 @@ output:
         {{import partial="os-config" combination="sw.os+arch.sw"}}
 
 
-        {{import partial="onbuild" combination="sw.os+arch.sw"}}
-
-
         COPY entry.sh /usr/bin/entry.sh
 
         ENTRYPOINT ["/usr/bin/entry.sh"]

--- a/scripts/blueprints/os-device.yaml
+++ b/scripts/blueprints/os-device.yaml
@@ -21,8 +21,4 @@ output:
 
         {{import partial="distro-config" combination="sw.os+hw.device-type"}}
 
-
         {{import partial="dependencies" combination="sw.os+hw.device-type"}}
-
-
-        {{import partial="onbuild" combination="sw.os+hw.device-type"}}

--- a/scripts/blueprints/stack-arch.yaml
+++ b/scripts/blueprints/stack-arch.yaml
@@ -24,6 +24,3 @@ output:
 
 
         {{import partial="cmd" combination="sw.stack+sw.os+hw.device-type"}}
-
-
-        {{import partial="onbuild" combination="sw.stack+sw.os+hw.device-type"}}

--- a/scripts/blueprints/stack-device.yaml
+++ b/scripts/blueprints/stack-device.yaml
@@ -25,6 +25,3 @@ output:
 
 
         {{import partial="cmd" combination="sw.stack+sw.os+hw.device-type"}}
-
-
-        {{import partial="onbuild" combination="sw.stack+sw.os+hw.device-type"}}


### PR DESCRIPTION
This reverts commit 1347d53b323885474e03948ea1a487b8a83b3ae0.
Since we must rethink how to properly implement this feature

Change-type: major
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>