### PR TITLE
entryscript: Use clean tmp mount when mounting /dev as devtmpfs

### DIFF
--- a/scripts/assets/entry-alpine.sh
+++ b/scripts/assets/entry-alpine.sh
@@ -9,18 +9,19 @@ fi
 
 function mount_dev()
 {
-	mkdir -p /tmp
-	mount -t devtmpfs none /tmp
-	mkdir -p /tmp/shm
-	mount --move /dev/shm /tmp/shm
-	mkdir -p /tmp/mqueue
-	mount --move /dev/mqueue /tmp/mqueue
-	mkdir -p /tmp/pts
-	mount --move /dev/pts /tmp/pts
-	touch /tmp/console
-	mount --move /dev/console /tmp/console
+	tmp_dir='/tmp/tmpmount'
+	mkdir -p "$tmp_dir"
+	mount -t devtmpfs none "$tmp_dir"
+	mkdir -p "$tmp_dir/shm"
+	mount --move /dev/shm "$tmp_dir/shm"
+	mkdir -p "$tmp_dir/mqueue"
+	mount --move /dev/mqueue "$tmp_dir/mqueue"
+	mkdir -p "$tmp_dir/pts"
+	mount --move /dev/pts "$tmp_dir/pts"
+	touch "$tmp_dir/console"
+	mount --move /dev/console "$tmp_dir/console"
 	umount /dev || true
-	mount --move /tmp /dev
+	mount --move "$tmp_dir" /dev
 
 	# Since the devpts is mounted with -o newinstance by Docker, we need to make
 	# /dev/ptmx point to its ptmx.

--- a/scripts/assets/entry.sh
+++ b/scripts/assets/entry.sh
@@ -9,18 +9,19 @@ fi
 
 function mount_dev()
 {
-	mkdir -p /tmp
-	mount -t devtmpfs none /tmp
-	mkdir -p /tmp/shm
-	mount --move /dev/shm /tmp/shm
-	mkdir -p /tmp/mqueue
-	mount --move /dev/mqueue /tmp/mqueue
-	mkdir -p /tmp/pts
-	mount --move /dev/pts /tmp/pts
-	touch /tmp/console
-	mount --move /dev/console /tmp/console
+	tmp_dir='/tmp/tmpmount'
+	mkdir -p "$tmp_dir"
+	mount -t devtmpfs none "$tmp_dir"
+	mkdir -p "$tmp_dir/shm"
+	mount --move /dev/shm "$tmp_dir/shm"
+	mkdir -p "$tmp_dir/mqueue"
+	mount --move /dev/mqueue "$tmp_dir/mqueue"
+	mkdir -p "$tmp_dir/pts"
+	mount --move /dev/pts "$tmp_dir/pts"
+	touch "$tmp_dir/console"
+	mount --move /dev/console "$tmp_dir/console"
 	umount /dev || true
-	mount --move /tmp /dev
+	mount --move "$tmp_dir" /dev
 
 	# Since the devpts is mounted with -o newinstance by Docker, we need to make
 	# /dev/ptmx point to its ptmx.


### PR DESCRIPTION
Use clean directory when mounting /dev as devtmpfs instead of /tmp to make sure it wont break other features

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>