### PR TITLE
entryscript: Fix the entry script in INITSYSTEM examples

### DIFF
--- a/examples/INITSYSTEM/openrc/entry.sh
+++ b/examples/INITSYSTEM/openrc/entry.sh
@@ -1,5 +1,46 @@
 #!/bin/bash
 
+if hostname "$HOSTNAME" &> /dev/null; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
+function start_udev()
+{
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" == "on" ]; then
+			rc-update add udev default
+		else
+			unshare --net udevd --daemon &> /dev/null
+			udevadm trigger &> /dev/null
+		fi
+	fi
+}
+
+function mount_dev()
+{
+	tmp_dir='/tmp/tmpmount'
+	mkdir -p "$tmp_dir"
+	mount -t devtmpfs none "$tmp_dir"
+	mkdir -p "$tmp_dir/shm"
+	mount --move /dev/shm "$tmp_dir/shm"
+	mkdir -p "$tmp_dir/mqueue"
+	mount --move /dev/mqueue "$tmp_dir/mqueue"
+	mkdir -p "$tmp_dir/pts"
+	mount --move /dev/pts "$tmp_dir/pts"
+	touch "$tmp_dir/console"
+	mount --move /dev/console "$tmp_dir/console"
+	umount /dev || true
+	mount --move "$tmp_dir" /dev
+
+	# Since the devpts is mounted with -o newinstance by Docker, we need to make
+	# /dev/ptmx point to its ptmx.
+	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+	ln -sf /dev/pts/ptmx /dev/ptmx
+	mount -t debugfs nodev /sys/kernel/debug
+}
+
 function init_openrc()
 {
 	GREEN='\033[0;32m'
@@ -38,6 +79,12 @@ case "$INITSYSTEM" in
 		INITSYSTEM='on'
 	;;
 esac
+
+if $PRIVILEGED; then
+	# Only run this in privileged container
+	mount_dev
+	start_udev
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/examples/INITSYSTEM/systemd/systemd.v230/entry.sh
+++ b/examples/INITSYSTEM/systemd/systemd.v230/entry.sh
@@ -2,10 +2,57 @@
 
 set -m
 
+if hostname "$HOSTNAME" &> /dev/null; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
 	kill "$pid"
+}
+
+function start_udev()
+{
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			if command -v udevd &>/dev/null; then
+				unshare --net udevd --daemon &> /dev/null
+			else
+				unshare --net /lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
+	else
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
+	fi
+}
+
+function mount_dev()
+{
+	tmp_dir='/tmp/tmpmount'
+	mkdir -p "$tmp_dir"
+	mount -t devtmpfs none "$tmp_dir"
+	mkdir -p "$tmp_dir/shm"
+	mount --move /dev/shm "$tmp_dir/shm"
+	mkdir -p "$tmp_dir/mqueue"
+	mount --move /dev/mqueue "$tmp_dir/mqueue"
+	mkdir -p "$tmp_dir/pts"
+	mount --move /dev/pts "$tmp_dir/pts"
+	touch "$tmp_dir/console"
+	mount --move /dev/console "$tmp_dir/console"
+	umount /dev || true
+	mount --move "$tmp_dir" /dev
+
+	# Since the devpts is mounted with -o newinstance by Docker, we need to make
+	# /dev/ptmx point to its ptmx.
+	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+	ln -sf /dev/pts/ptmx /dev/ptmx
+	mount -t debugfs nodev /sys/kernel/debug
 }
 
 function init_systemd()
@@ -57,6 +104,12 @@ case "$INITSYSTEM" in
 		INITSYSTEM='on'
 	;;
 esac
+
+if $PRIVILEGED; then
+	# Only run this in privileged container
+	mount_dev
+	start_udev
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/examples/INITSYSTEM/systemd/systemd/entry.sh
+++ b/examples/INITSYSTEM/systemd/systemd/entry.sh
@@ -2,10 +2,57 @@
 
 set -m
 
+if hostname "$HOSTNAME" &> /dev/null; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
 	kill "$pid"
+}
+
+function start_udev()
+{
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			if command -v udevd &>/dev/null; then
+				unshare --net udevd --daemon &> /dev/null
+			else
+				unshare --net /lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
+	else
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
+	fi
+}
+
+function mount_dev()
+{
+	tmp_dir='/tmp/tmpmount'
+	mkdir -p "$tmp_dir"
+	mount -t devtmpfs none "$tmp_dir"
+	mkdir -p "$tmp_dir/shm"
+	mount --move /dev/shm "$tmp_dir/shm"
+	mkdir -p "$tmp_dir/mqueue"
+	mount --move /dev/mqueue "$tmp_dir/mqueue"
+	mkdir -p "$tmp_dir/pts"
+	mount --move /dev/pts "$tmp_dir/pts"
+	touch "$tmp_dir/console"
+	mount --move /dev/console "$tmp_dir/console"
+	umount /dev || true
+	mount --move "$tmp_dir" /dev
+
+	# Since the devpts is mounted with -o newinstance by Docker, we need to make
+	# /dev/ptmx point to its ptmx.
+	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+	ln -sf /dev/pts/ptmx /dev/ptmx
+	mount -t debugfs nodev /sys/kernel/debug
 }
 
 function init_systemd()
@@ -57,6 +104,12 @@ case "$INITSYSTEM" in
 		INITSYSTEM='on'
 	;;
 esac
+
+if $PRIVILEGED; then
+	# Only run this in privileged container
+	mount_dev
+	start_udev
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"


### PR DESCRIPTION
Fix #524, start udev and mount /dev as devtmpfs in the entry script of INITSYSTEM example.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>