### PR TITLE
systemd: Update systemd examples to use Buster base images

### DIFF
--- a/examples/INITSYSTEM/systemd/systemd.v230/Dockerfile
+++ b/examples/INITSYSTEM/systemd/systemd.v230/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/amd64-debian:stretch
+FROM balenalib/amd64-debian:buster
 
 # Install Systemd
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/examples/INITSYSTEM/systemd/systemd.v230/entry.sh
+++ b/examples/INITSYSTEM/systemd/systemd.v230/entry.sh
@@ -75,7 +75,7 @@ function init_systemd()
 	EOF
 
 	sleep infinity &
-	exec env DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket /sbin/init quiet systemd.show_status=0
+	exec env DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket SYSTEMD_LOG_LEVEL=info /sbin/init quiet systemd.show_status=0
 }
 
 function init_non_systemd()


### PR DESCRIPTION
Change to Debian Buster base image since it is the latest tag for Debian.
Set default SYSTEMD_LOG_LEVEL=info to get rid of noisy init log

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>