### PR TITLE
entryscript: Change how entry script detects privileged container

### DIFF
--- a/examples/INITSYSTEM/openrc/entry.sh
+++ b/examples/INITSYSTEM/openrc/entry.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-if hostname "$HOSTNAME" &> /dev/null; then
+# This command only works in privileged container
+ip link add dummy0 type dummy &> /dev/null
+if [[ $? == 0 ]]; then
 	PRIVILEGED=true
+	# clean the dummy0 link
+    ip link delete dummy0 &> /dev/null
 else
 	PRIVILEGED=false
 fi

--- a/examples/INITSYSTEM/systemd/systemd.v230/entry.sh
+++ b/examples/INITSYSTEM/systemd/systemd.v230/entry.sh
@@ -2,8 +2,12 @@
 
 set -m
 
-if hostname "$HOSTNAME" &> /dev/null; then
+# This command only works in privileged container
+ip link add dummy0 type dummy &> /dev/null
+if [[ $? == 0 ]]; then
 	PRIVILEGED=true
+	# clean the dummy0 link
+    ip link delete dummy0 &> /dev/null
 else
 	PRIVILEGED=false
 fi

--- a/examples/INITSYSTEM/systemd/systemd/entry.sh
+++ b/examples/INITSYSTEM/systemd/systemd/entry.sh
@@ -2,8 +2,12 @@
 
 set -m
 
-if hostname "$HOSTNAME" &> /dev/null; then
+# This command only works in privileged container
+ip link add dummy0 type dummy &> /dev/null
+if [[ $? == 0 ]]; then
 	PRIVILEGED=true
+	# clean the dummy0 link
+    ip link delete dummy0 &> /dev/null
 else
 	PRIVILEGED=false
 fi

--- a/scripts/assets/entry-alpine.sh
+++ b/scripts/assets/entry-alpine.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-hostname "$HOSTNAME" &> /dev/null
+# This command only works in privileged container
+ip link add dummy0 type dummy &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
+	# clean the dummy0 link
+    ip link delete dummy0 &> /dev/null
 else
 	PRIVILEGED=false
 fi

--- a/scripts/assets/entry.sh
+++ b/scripts/assets/entry.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-hostname "$HOSTNAME" &> /dev/null
+# This command only works in privileged container
+ip link add dummy0 type dummy &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
+	# clean the dummy0 link
+    ip link delete dummy0 &> /dev/null
 else
 	PRIVILEGED=false
 fi


### PR DESCRIPTION
Fixes https://jel.ly.fish/f5b9dd78-235c-4c93-ba1a-6a6691f48650

Since user can set value for HOSTNAME env var, if the value is not a valid host name then the entry script will always return it as unprivileged container.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>