### PR TITLE
balena-base-images: Add l4t-core workaround for all Jetson images

### DIFF
--- a/balena-base-images/device-base/jetson-nano-emmc/debian/bullseye/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano-emmc/debian/bullseye/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-build
 LABEL io.balena.device-type="jetson-nano-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano-emmc/debian/bullseye/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano-emmc/debian/bullseye/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-run
 LABEL io.balena.device-type="jetson-nano-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano-emmc/debian/buster/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano-emmc/debian/buster/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-build
 LABEL io.balena.device-type="jetson-nano-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano-emmc/debian/buster/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano-emmc/debian/buster/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-run
 LABEL io.balena.device-type="jetson-nano-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano-emmc/debian/jessie/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano-emmc/debian/jessie/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-build
 LABEL io.balena.device-type="jetson-nano-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano-emmc/debian/jessie/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano-emmc/debian/jessie/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-run
 LABEL io.balena.device-type="jetson-nano-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano-emmc/debian/sid/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano-emmc/debian/sid/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-build
 LABEL io.balena.device-type="jetson-nano-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano-emmc/debian/sid/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano-emmc/debian/sid/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-run
 LABEL io.balena.device-type="jetson-nano-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano-emmc/debian/stretch/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano-emmc/debian/stretch/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-build
 LABEL io.balena.device-type="jetson-nano-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano-emmc/debian/stretch/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano-emmc/debian/stretch/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-run
 LABEL io.balena.device-type="jetson-nano-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano/debian/bullseye/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano/debian/bullseye/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-build
 LABEL io.balena.device-type="jetson-nano"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano/debian/bullseye/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano/debian/bullseye/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-run
 LABEL io.balena.device-type="jetson-nano"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano/debian/buster/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano/debian/buster/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-build
 LABEL io.balena.device-type="jetson-nano"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano/debian/buster/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano/debian/buster/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-run
 LABEL io.balena.device-type="jetson-nano"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano/debian/jessie/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano/debian/jessie/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-build
 LABEL io.balena.device-type="jetson-nano"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano/debian/jessie/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano/debian/jessie/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-run
 LABEL io.balena.device-type="jetson-nano"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano/debian/sid/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano/debian/sid/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-build
 LABEL io.balena.device-type="jetson-nano"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano/debian/sid/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano/debian/sid/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-run
 LABEL io.balena.device-type="jetson-nano"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano/debian/stretch/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano/debian/stretch/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-build
 LABEL io.balena.device-type="jetson-nano"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-nano/debian/stretch/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-nano/debian/stretch/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-run
 LABEL io.balena.device-type="jetson-nano"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx1/debian/bullseye/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx1/debian/bullseye/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-build
 LABEL io.balena.device-type="jetson-tx1"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx1/debian/bullseye/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx1/debian/bullseye/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-run
 LABEL io.balena.device-type="jetson-tx1"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx1/debian/buster/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx1/debian/buster/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-build
 LABEL io.balena.device-type="jetson-tx1"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx1/debian/buster/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx1/debian/buster/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-run
 LABEL io.balena.device-type="jetson-tx1"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx1/debian/jessie/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx1/debian/jessie/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-build
 LABEL io.balena.device-type="jetson-tx1"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx1/debian/jessie/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx1/debian/jessie/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-run
 LABEL io.balena.device-type="jetson-tx1"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx1/debian/sid/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx1/debian/sid/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-build
 LABEL io.balena.device-type="jetson-tx1"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx1/debian/sid/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx1/debian/sid/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-run
 LABEL io.balena.device-type="jetson-tx1"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx1/debian/stretch/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx1/debian/stretch/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-build
 LABEL io.balena.device-type="jetson-tx1"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx1/debian/stretch/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx1/debian/stretch/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-run
 LABEL io.balena.device-type="jetson-tx1"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx2/debian/bullseye/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx2/debian/bullseye/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-build
 LABEL io.balena.device-type="jetson-tx2"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx2/debian/bullseye/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx2/debian/bullseye/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-run
 LABEL io.balena.device-type="jetson-tx2"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx2/debian/buster/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx2/debian/buster/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-build
 LABEL io.balena.device-type="jetson-tx2"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx2/debian/buster/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx2/debian/buster/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-run
 LABEL io.balena.device-type="jetson-tx2"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx2/debian/jessie/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx2/debian/jessie/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-build
 LABEL io.balena.device-type="jetson-tx2"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx2/debian/jessie/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx2/debian/jessie/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-run
 LABEL io.balena.device-type="jetson-tx2"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx2/debian/sid/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx2/debian/sid/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-build
 LABEL io.balena.device-type="jetson-tx2"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx2/debian/sid/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx2/debian/sid/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-run
 LABEL io.balena.device-type="jetson-tx2"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx2/debian/stretch/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx2/debian/stretch/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-build
 LABEL io.balena.device-type="jetson-tx2"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-tx2/debian/stretch/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-tx2/debian/stretch/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-run
 LABEL io.balena.device-type="jetson-tx2"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/bullseye/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/bullseye/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-build
 LABEL io.balena.device-type="jetson-xavier-nx-devkit-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/bullseye/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/bullseye/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-run
 LABEL io.balena.device-type="jetson-xavier-nx-devkit-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/buster/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/buster/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-build
 LABEL io.balena.device-type="jetson-xavier-nx-devkit-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/buster/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/buster/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-run
 LABEL io.balena.device-type="jetson-xavier-nx-devkit-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/jessie/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/jessie/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-build
 LABEL io.balena.device-type="jetson-xavier-nx-devkit-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/jessie/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/jessie/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-run
 LABEL io.balena.device-type="jetson-xavier-nx-devkit-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/sid/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/sid/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-build
 LABEL io.balena.device-type="jetson-xavier-nx-devkit-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/sid/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/sid/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-run
 LABEL io.balena.device-type="jetson-xavier-nx-devkit-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/stretch/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/stretch/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-build
 LABEL io.balena.device-type="jetson-xavier-nx-devkit-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/stretch/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier-nx-devkit-emmc/debian/stretch/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-run
 LABEL io.balena.device-type="jetson-xavier-nx-devkit-emmc"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier/debian/bullseye/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier/debian/bullseye/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-build
 LABEL io.balena.device-type="jetson-xavier"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier/debian/bullseye/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier/debian/bullseye/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:bullseye-run
 LABEL io.balena.device-type="jetson-xavier"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier/debian/buster/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier/debian/buster/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-build
 LABEL io.balena.device-type="jetson-xavier"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier/debian/buster/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier/debian/buster/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:buster-run
 LABEL io.balena.device-type="jetson-xavier"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier/debian/jessie/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier/debian/jessie/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-build
 LABEL io.balena.device-type="jetson-xavier"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier/debian/jessie/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier/debian/jessie/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:jessie-run
 LABEL io.balena.device-type="jetson-xavier"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier/debian/sid/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier/debian/sid/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-build
 LABEL io.balena.device-type="jetson-xavier"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier/debian/sid/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier/debian/sid/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:sid-run
 LABEL io.balena.device-type="jetson-xavier"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier/debian/stretch/build/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier/debian/stretch/build/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-build
 LABEL io.balena.device-type="jetson-xavier"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/balena-base-images/device-base/jetson-xavier/debian/stretch/run/Dockerfile
+++ b/balena-base-images/device-base/jetson-xavier/debian/stretch/run/Dockerfile
@@ -2,7 +2,8 @@ FROM balenalib/aarch64-debian:stretch-run
 LABEL io.balena.device-type="jetson-xavier"
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \


### PR DESCRIPTION
This adds a workaround for installing a dependency
called nvidia-l4t-core from the public debs.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>