### PR TITLE
entryscript: check if sys/kernel mount point already exists

### DIFF
--- a/scripts/assets/entry-alpine.sh
+++ b/scripts/assets/entry-alpine.sh
@@ -31,7 +31,15 @@ function mount_dev()
 	# /dev/ptmx point to its ptmx.
 	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
 	ln -sf /dev/pts/ptmx /dev/ptmx
-	mount -t debugfs nodev /sys/kernel/debug
+
+	# When using io.balena.features.sysfs the mount point will already exist
+	# we need to check the mountpoint first.
+	sysfs_dir='/sys/kernel/debug'
+
+	if ! mountpoint -q "$sysfs_dir"; then
+		mount -t debugfs nodev "$sysfs_dir"
+	fi
+	
 }
 
 function start_udev()

--- a/scripts/assets/entry.sh
+++ b/scripts/assets/entry.sh
@@ -31,7 +31,15 @@ function mount_dev()
 	# /dev/ptmx point to its ptmx.
 	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
 	ln -sf /dev/pts/ptmx /dev/ptmx
-	mount -t debugfs nodev /sys/kernel/debug
+
+	# When using io.balena.features.sysfs the mount point will already exist
+	# we need to check the mountpoint first.
+	sysfs_dir='/sys/kernel/debug'
+
+	if ! mountpoint -q "$sysfs_dir"; then
+		mount -t debugfs nodev "$sysfs_dir"
+	fi
+
 }
 
 function start_udev()


### PR DESCRIPTION
Since the supervisor can bind mount the host OS /sys into the container if io.balena.features.sysfs is set
we need to check whether it exists or not before mounting in the base-images entryscript

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>