### PR TITLE
Iterate the contrato.query for a concurrency of 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@balena/contrato": "^0.9.0",
+        "@balena/contrato": "^0.9.1",
         "fs-extra": "^7.0.1",
         "js-combinatorics": "^0.5.3",
         "js-yaml": "^3.11.0",
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@balena/contrato": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@balena/contrato/-/contrato-0.9.0.tgz",
-      "integrity": "sha512-RqbIElsA/VGCxwmivTeb3yswWx9CkRNmF9xNwnQPx+6F2uih6dIIJp1BJnSuv5TYU5XVAep97Qr4qKuJhPmGsA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@balena/contrato/-/contrato-0.9.1.tgz",
+      "integrity": "sha512-vFAkdae+T3L3LQrMj1hCEm/tolxROUsC7Gic0iVVHqAP0cAoDcSfdBMUIXDFhrq/M8m0zfvNkbPAQggLEhjpDA==",
       "dependencies": {
         "@types/debug": "^4.1.5",
         "@types/js-combinatorics": "^0.5.32",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Resin Inc. <hello@resin.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@balena/contrato": "^0.9.0",
+    "@balena/contrato": "^0.9.1",
     "fs-extra": "^7.0.1",
     "js-combinatorics": "^0.5.3",
     "js-yaml": "^3.11.0",

--- a/scripts/generate-dockerfiles.js
+++ b/scripts/generate-dockerfiles.js
@@ -21,6 +21,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const contrato = require('@balena/contrato')
 const yaml = require('js-yaml')
+const { concurrentForEach } = require('./utils')
 
 const DEST_DIR = path.join(__dirname, '../balena-base-images')
 const BLUEPRINT_PATHS = {
@@ -97,7 +98,7 @@ if (types.indexOf('all') > -1) {
 
     // Write output
     let count = 0
-    for (const context of result) {
+    await concurrentForEach(result, 5, async (context) => {
       const json = context.toJSON()
       const destination = path.join(
         DEST_DIR,
@@ -124,7 +125,7 @@ if (types.indexOf('all') > -1) {
         }
       }
       count++
-    }
+    })
 
     console.log(`Generated ${count} results out of ${universe.getChildren().length} contracts`)
     console.log(`Adding generated ${count} contracts back to the universe`)

--- a/scripts/generate-dockerhub-description.js
+++ b/scripts/generate-dockerhub-description.js
@@ -21,6 +21,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const contrato = require('@balena/contrato')
 const yaml = require('js-yaml')
+const { concurrentForEach } = require('./utils')
 
 const DEST_DIR = path.join(__dirname, '../balena-base-images')
 const BLUEPRINT_PATHS = {
@@ -91,7 +92,7 @@ if (types.indexOf('all') > -1) {
     const template = query.output.template[0].data
 
     // Write output
-    for (const context of result) {
+    await concurrentForEach(result, 5, async (context) => {
       const json = context.toJSON()
       const destination = path.join(
         DEST_DIR,
@@ -105,6 +106,6 @@ if (types.indexOf('all') > -1) {
           directory: CONTRACTS_PATH
         }))
       }
-    }
+    })
   }))
 })()

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 balena.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+exports.concurrentForEach = async (/** @type IterableIterator<Contract> */ it, /** @type number */ concurrency, /** @type {(context: Contract) => Promise<void>} */fn) => {
+  const run = async () => {
+    const next = it.next()
+    if (next.value && !next.done) {
+      await fn(next.value)
+      await run()
+    }
+  }
+  const runs = []
+  for (let i = 0; i < concurrency; i++) {
+    runs.push(run())
+  }
+  await Promise.all(runs)
+}


### PR DESCRIPTION
This allows for more concurrent work whilst still limiting the number of contracts we process concurrently to avoid excessive memory usage

Change-type: patch