### PR TITLE
Generate a subset of files and libraries via npm test

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 balena-base-images/
+library/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "all": "node scripts/generate-dockerfiles.js all",
     "all-lib": "node scripts/generate-stackbrew-library.js all",
     "all-dockerhub": "node scripts/generate-dockerhub-description.js all",
-    "test": "echo \"Error: no tests specified\" && exit 0"
+    "test": "time -p npm run os-arch && time -p npm run os-arch-lib"
   },
   "author": "Resin Inc. <hello@resin.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is useful to benchmark generation times.

Change-type: patch

```
Generated 162 results out of 408 contracts
Adding generated 162 contracts back to the universe
real 5.23
user 5.17
sys 1.36

> base-img-generator@2.1.6 os-arch-lib
> node scripts/generate-stackbrew-library.js os-arch

Generated 172 results out of 409 contracts
Adding generated 172 contracts back to the universe
real 4.11
user 3.90
sys 1.88
```