### PR TITLE
Skip aliases from contract processing

### DIFF
--- a/scripts/generate-dockerfiles.js
+++ b/scripts/generate-dockerfiles.js
@@ -38,7 +38,10 @@ const allContracts = require('require-all')({
 	filter: /.json$/,
 	recursive: true,
 	resolve: (json) => {
-		return contrato.Contract.build(json);
+		// We only want to generate dockerfiles for the
+		// canonical contracts
+		const { aliases, ...obj } = json;
+		return contrato.Contract.build(obj);
 	},
 });
 
@@ -149,9 +152,9 @@ if (types.indexOf('all') > -1) {
 							} catch (err) {
 								throw new Error(
 									'Error when copying ' +
-										blob.assets.bin.name +
-										' to ' +
-										path.dirname(destination),
+									blob.assets.bin.name +
+									' to ' +
+									path.dirname(destination),
 								);
 							}
 						}
@@ -161,8 +164,7 @@ if (types.indexOf('all') > -1) {
 			});
 
 			console.log(
-				`Generated ${count} results out of ${
-					universe.getChildren().length
+				`Generated ${count} results out of ${universe.getChildren().length
 				} contracts`,
 			);
 			console.log(`Adding generated ${count} contracts back to the universe`);

--- a/scripts/generate-dockerhub-description.js
+++ b/scripts/generate-dockerhub-description.js
@@ -50,7 +50,10 @@ const allContracts = require('require-all')({
 	filter: /.json$/,
 	recursive: true,
 	resolve: (json) => {
-		return contrato.Contract.build(json);
+		// We only want to process the
+		// canonical version of the contract
+		const { aliases, ...obj } = json;
+		return contrato.Contract.build(obj);
 	},
 });
 

--- a/scripts/generate-stackbrew-library.js
+++ b/scripts/generate-stackbrew-library.js
@@ -219,7 +219,10 @@ const allContracts = require('require-all')({
 	filter: /.json$/,
 	recursive: true,
 	resolve: (json) => {
-		return contrato.Contract.build(json);
+		// We only want to process the
+		// canonical version of the contract
+		const { aliases, ...obj } = json;
+		return contrato.Contract.build(obj);
 	},
 });
 
@@ -312,8 +315,7 @@ if (types.indexOf('all') > -1) {
 			});
 
 			console.log(
-				`Generated ${count} results out of ${
-					universe.getChildren().length
+				`Generated ${count} results out of ${universe.getChildren().length
 				} contracts`,
 			);
 			console.log(`Adding generated ${count} contracts back to the universe`);


### PR DESCRIPTION
We only want to generate Dockerfiles for the canonical device type names and not their aliases. Ex. There is a `raspberry-pi2-alpine-python` image but not a `raspberrypi2-alpine-python` image. This removes the aliases before building the contract to prevent the universe reproduction to generate combinations for those aliases as well.

Change-type: minor