### PR TITLE
Use self-hosted X64 runners with QEMU for building images

### DIFF
--- a/.github/bashbrew.json
+++ b/.github/bashbrew.json
@@ -2,27 +2,27 @@
   "aarch64": {
     "library": "aarch64",
     "platform": "linux/arm64",
-    "runner": ["ubuntu-latest"]
+    "runner": ["self-hosted","base-images","X64"]
   },
   "amd64": {
     "library": "amd64",
     "platform": "linux/amd64",
-    "runner": ["ubuntu-latest"]
+    "runner": ["self-hosted","base-images","X64"]
   },
   "armv7hf": {
     "library": "armv7hf",
     "platform": "linux/arm/v7",
-    "runner": ["ubuntu-latest"]
+    "runner": ["self-hosted","base-images","X64"]
   },
   "i386": {
     "library": "i386",
     "platform": "linux/386",
-    "runner": ["ubuntu-latest"]
+    "runner": ["self-hosted","base-images","X64"]
   },
   "rpi": {
     "library": "rpi",
     "platform": "linux/arm/v5",
-    "runner": ["ubuntu-latest"]
+    "runner": ["self-hosted","base-images","X64"]
   },
   "beaglebone": {
     "library": "beaglebone-black",

--- a/.github/workflows/bashbrew-aarch64.yml
+++ b/.github/workflows/bashbrew-aarch64.yml
@@ -199,29 +199,17 @@ concurrency:
 jobs:
   aarch64-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'aarch64-alpine' || inputs.target_job == 'all' || inputs.target_job == 'aarch64-alpine-golang' || inputs.target_job == 'aarch64-alpine-node' || inputs.target_job == 'aarch64-alpine-openjdk' || inputs.target_job == 'aarch64-alpine-python' || inputs.target_job == 'coral-dev-alpine' || inputs.target_job == 'generic-aarch64-alpine' || inputs.target_job == 'jetson-orin-alpine' || inputs.target_job == 'jetson-nano-alpine' || inputs.target_job == 'jetson-tx2-alpine' || inputs.target_job == 'jetson-xavier-alpine' || inputs.target_job == 'raspberrypi-aarch64-alpine'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -246,30 +234,18 @@ jobs:
           retention-days: 90
   aarch64-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-alpine
     if: inputs.target_job == 'aarch64-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -294,30 +270,18 @@ jobs:
           retention-days: 90
   aarch64-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-alpine
     if: inputs.target_job == 'aarch64-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -342,30 +306,18 @@ jobs:
           retention-days: 90
   aarch64-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-alpine
     if: inputs.target_job == 'aarch64-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -390,30 +342,18 @@ jobs:
           retention-days: 90
   aarch64-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-alpine
     if: inputs.target_job == 'aarch64-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -438,29 +378,17 @@ jobs:
           retention-days: 90
   aarch64-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'aarch64-debian' || inputs.target_job == 'all' || inputs.target_job == 'aarch64-debian-golang' || inputs.target_job == 'aarch64-debian-node' || inputs.target_job == 'aarch64-debian-openjdk' || inputs.target_job == 'aarch64-debian-python' || inputs.target_job == 'coral-dev-debian' || inputs.target_job == 'generic-aarch64-debian' || inputs.target_job == 'jetson-orin-debian' || inputs.target_job == 'jetson-nano-debian' || inputs.target_job == 'jetson-tx2-debian' || inputs.target_job == 'jetson-xavier-debian' || inputs.target_job == 'raspberrypi-aarch64-debian'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -485,30 +413,18 @@ jobs:
           retention-days: 90
   aarch64-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-debian
     if: inputs.target_job == 'aarch64-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -533,30 +449,18 @@ jobs:
           retention-days: 90
   aarch64-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-debian
     if: inputs.target_job == 'aarch64-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -581,30 +485,18 @@ jobs:
           retention-days: 90
   aarch64-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-debian
     if: inputs.target_job == 'aarch64-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -629,30 +521,18 @@ jobs:
           retention-days: 90
   aarch64-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-debian
     if: inputs.target_job == 'aarch64-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -677,29 +557,17 @@ jobs:
           retention-days: 90
   aarch64-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'aarch64-fedora' || inputs.target_job == 'all' || inputs.target_job == 'aarch64-fedora-golang' || inputs.target_job == 'aarch64-fedora-node' || inputs.target_job == 'aarch64-fedora-openjdk' || inputs.target_job == 'aarch64-fedora-python' || inputs.target_job == 'coral-dev-fedora' || inputs.target_job == 'generic-aarch64-fedora' || inputs.target_job == 'jetson-orin-fedora' || inputs.target_job == 'jetson-nano-fedora' || inputs.target_job == 'jetson-tx2-fedora' || inputs.target_job == 'jetson-xavier-fedora' || inputs.target_job == 'raspberrypi-aarch64-fedora'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -724,30 +592,18 @@ jobs:
           retention-days: 90
   aarch64-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-fedora
     if: inputs.target_job == 'aarch64-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -772,30 +628,18 @@ jobs:
           retention-days: 90
   aarch64-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-fedora
     if: inputs.target_job == 'aarch64-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -820,30 +664,18 @@ jobs:
           retention-days: 90
   aarch64-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-fedora
     if: inputs.target_job == 'aarch64-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -868,30 +700,18 @@ jobs:
           retention-days: 90
   aarch64-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-fedora
     if: inputs.target_job == 'aarch64-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -916,29 +736,17 @@ jobs:
           retention-days: 90
   aarch64-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'aarch64-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'aarch64-ubuntu-golang' || inputs.target_job == 'aarch64-ubuntu-node' || inputs.target_job == 'aarch64-ubuntu-openjdk' || inputs.target_job == 'aarch64-ubuntu-python' || inputs.target_job == 'coral-dev-ubuntu' || inputs.target_job == 'generic-aarch64-ubuntu' || inputs.target_job == 'jetson-orin-ubuntu' || inputs.target_job == 'jetson-nano-ubuntu' || inputs.target_job == 'jetson-tx2-ubuntu' || inputs.target_job == 'jetson-xavier-ubuntu' || inputs.target_job == 'raspberrypi-aarch64-ubuntu'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -963,30 +771,18 @@ jobs:
           retention-days: 90
   aarch64-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-ubuntu
     if: inputs.target_job == 'aarch64-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1011,30 +807,18 @@ jobs:
           retention-days: 90
   aarch64-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-ubuntu
     if: inputs.target_job == 'aarch64-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1059,30 +843,18 @@ jobs:
           retention-days: 90
   aarch64-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-ubuntu
     if: inputs.target_job == 'aarch64-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1107,30 +879,18 @@ jobs:
           retention-days: 90
   aarch64-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-ubuntu
     if: inputs.target_job == 'aarch64-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1155,30 +915,18 @@ jobs:
           retention-days: 90
   coral-dev-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-alpine
     if: inputs.target_job == 'coral-dev-alpine' || inputs.target_job == 'all' || inputs.target_job == 'coral-dev-alpine-golang' || inputs.target_job == 'coral-dev-alpine-node' || inputs.target_job == 'coral-dev-alpine-openjdk' || inputs.target_job == 'coral-dev-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1203,30 +951,18 @@ jobs:
           retention-days: 90
   coral-dev-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-alpine
     if: inputs.target_job == 'coral-dev-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1251,30 +987,18 @@ jobs:
           retention-days: 90
   coral-dev-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-alpine
     if: inputs.target_job == 'coral-dev-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1299,30 +1023,18 @@ jobs:
           retention-days: 90
   coral-dev-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-alpine
     if: inputs.target_job == 'coral-dev-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1347,30 +1059,18 @@ jobs:
           retention-days: 90
   coral-dev-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-alpine
     if: inputs.target_job == 'coral-dev-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1395,30 +1095,18 @@ jobs:
           retention-days: 90
   coral-dev-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-debian
     if: inputs.target_job == 'coral-dev-debian' || inputs.target_job == 'all' || inputs.target_job == 'coral-dev-debian-golang' || inputs.target_job == 'coral-dev-debian-node' || inputs.target_job == 'coral-dev-debian-openjdk' || inputs.target_job == 'coral-dev-debian-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1443,30 +1131,18 @@ jobs:
           retention-days: 90
   coral-dev-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-debian
     if: inputs.target_job == 'coral-dev-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1491,30 +1167,18 @@ jobs:
           retention-days: 90
   coral-dev-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-debian
     if: inputs.target_job == 'coral-dev-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1539,30 +1203,18 @@ jobs:
           retention-days: 90
   coral-dev-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-debian
     if: inputs.target_job == 'coral-dev-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1587,30 +1239,18 @@ jobs:
           retention-days: 90
   coral-dev-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-debian
     if: inputs.target_job == 'coral-dev-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1635,30 +1275,18 @@ jobs:
           retention-days: 90
   coral-dev-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-fedora
     if: inputs.target_job == 'coral-dev-fedora' || inputs.target_job == 'all' || inputs.target_job == 'coral-dev-fedora-golang' || inputs.target_job == 'coral-dev-fedora-node' || inputs.target_job == 'coral-dev-fedora-openjdk' || inputs.target_job == 'coral-dev-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1683,30 +1311,18 @@ jobs:
           retention-days: 90
   coral-dev-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-fedora
     if: inputs.target_job == 'coral-dev-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1731,30 +1347,18 @@ jobs:
           retention-days: 90
   coral-dev-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-fedora
     if: inputs.target_job == 'coral-dev-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1779,30 +1383,18 @@ jobs:
           retention-days: 90
   coral-dev-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-fedora
     if: inputs.target_job == 'coral-dev-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1827,30 +1419,18 @@ jobs:
           retention-days: 90
   coral-dev-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-fedora
     if: inputs.target_job == 'coral-dev-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1875,30 +1455,18 @@ jobs:
           retention-days: 90
   coral-dev-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-ubuntu
     if: inputs.target_job == 'coral-dev-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'coral-dev-ubuntu-golang' || inputs.target_job == 'coral-dev-ubuntu-node' || inputs.target_job == 'coral-dev-ubuntu-openjdk' || inputs.target_job == 'coral-dev-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1923,30 +1491,18 @@ jobs:
           retention-days: 90
   coral-dev-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-ubuntu
     if: inputs.target_job == 'coral-dev-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1971,30 +1527,18 @@ jobs:
           retention-days: 90
   coral-dev-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-ubuntu
     if: inputs.target_job == 'coral-dev-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2019,30 +1563,18 @@ jobs:
           retention-days: 90
   coral-dev-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-ubuntu
     if: inputs.target_job == 'coral-dev-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2067,30 +1599,18 @@ jobs:
           retention-days: 90
   coral-dev-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - coral-dev-ubuntu
     if: inputs.target_job == 'coral-dev-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'coral-dev-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2115,30 +1635,18 @@ jobs:
           retention-days: 90
   generic-aarch64-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-alpine
     if: inputs.target_job == 'generic-aarch64-alpine' || inputs.target_job == 'all' || inputs.target_job == 'generic-aarch64-alpine-golang' || inputs.target_job == 'generic-aarch64-alpine-node' || inputs.target_job == 'generic-aarch64-alpine-openjdk' || inputs.target_job == 'generic-aarch64-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2163,30 +1671,18 @@ jobs:
           retention-days: 90
   generic-aarch64-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-alpine
     if: inputs.target_job == 'generic-aarch64-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2211,30 +1707,18 @@ jobs:
           retention-days: 90
   generic-aarch64-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-alpine
     if: inputs.target_job == 'generic-aarch64-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2259,30 +1743,18 @@ jobs:
           retention-days: 90
   generic-aarch64-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-alpine
     if: inputs.target_job == 'generic-aarch64-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2307,30 +1779,18 @@ jobs:
           retention-days: 90
   generic-aarch64-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-alpine
     if: inputs.target_job == 'generic-aarch64-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2355,30 +1815,18 @@ jobs:
           retention-days: 90
   generic-aarch64-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-debian
     if: inputs.target_job == 'generic-aarch64-debian' || inputs.target_job == 'all' || inputs.target_job == 'generic-aarch64-debian-golang' || inputs.target_job == 'generic-aarch64-debian-node' || inputs.target_job == 'generic-aarch64-debian-openjdk' || inputs.target_job == 'generic-aarch64-debian-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2403,30 +1851,18 @@ jobs:
           retention-days: 90
   generic-aarch64-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-debian
     if: inputs.target_job == 'generic-aarch64-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2451,30 +1887,18 @@ jobs:
           retention-days: 90
   generic-aarch64-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-debian
     if: inputs.target_job == 'generic-aarch64-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2499,30 +1923,18 @@ jobs:
           retention-days: 90
   generic-aarch64-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-debian
     if: inputs.target_job == 'generic-aarch64-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2547,30 +1959,18 @@ jobs:
           retention-days: 90
   generic-aarch64-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-debian
     if: inputs.target_job == 'generic-aarch64-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2595,30 +1995,18 @@ jobs:
           retention-days: 90
   generic-aarch64-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-fedora
     if: inputs.target_job == 'generic-aarch64-fedora' || inputs.target_job == 'all' || inputs.target_job == 'generic-aarch64-fedora-golang' || inputs.target_job == 'generic-aarch64-fedora-node' || inputs.target_job == 'generic-aarch64-fedora-openjdk' || inputs.target_job == 'generic-aarch64-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2643,30 +2031,18 @@ jobs:
           retention-days: 90
   generic-aarch64-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-fedora
     if: inputs.target_job == 'generic-aarch64-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2691,30 +2067,18 @@ jobs:
           retention-days: 90
   generic-aarch64-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-fedora
     if: inputs.target_job == 'generic-aarch64-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2739,30 +2103,18 @@ jobs:
           retention-days: 90
   generic-aarch64-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-fedora
     if: inputs.target_job == 'generic-aarch64-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2787,30 +2139,18 @@ jobs:
           retention-days: 90
   generic-aarch64-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-fedora
     if: inputs.target_job == 'generic-aarch64-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2835,30 +2175,18 @@ jobs:
           retention-days: 90
   generic-aarch64-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-ubuntu
     if: inputs.target_job == 'generic-aarch64-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'generic-aarch64-ubuntu-golang' || inputs.target_job == 'generic-aarch64-ubuntu-node' || inputs.target_job == 'generic-aarch64-ubuntu-openjdk' || inputs.target_job == 'generic-aarch64-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2883,30 +2211,18 @@ jobs:
           retention-days: 90
   generic-aarch64-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-ubuntu
     if: inputs.target_job == 'generic-aarch64-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2931,30 +2247,18 @@ jobs:
           retention-days: 90
   generic-aarch64-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-ubuntu
     if: inputs.target_job == 'generic-aarch64-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2979,30 +2283,18 @@ jobs:
           retention-days: 90
   generic-aarch64-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-ubuntu
     if: inputs.target_job == 'generic-aarch64-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3027,30 +2319,18 @@ jobs:
           retention-days: 90
   generic-aarch64-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-aarch64-ubuntu
     if: inputs.target_job == 'generic-aarch64-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-aarch64-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3075,30 +2355,18 @@ jobs:
           retention-days: 90
   jetson-orin-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-alpine
     if: inputs.target_job == 'jetson-orin-alpine' || inputs.target_job == 'all' || inputs.target_job == 'jetson-orin-alpine-golang' || inputs.target_job == 'jetson-orin-alpine-node' || inputs.target_job == 'jetson-orin-alpine-openjdk' || inputs.target_job == 'jetson-orin-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3123,30 +2391,18 @@ jobs:
           retention-days: 90
   jetson-orin-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-alpine
     if: inputs.target_job == 'jetson-orin-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3171,30 +2427,18 @@ jobs:
           retention-days: 90
   jetson-orin-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-alpine
     if: inputs.target_job == 'jetson-orin-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3219,30 +2463,18 @@ jobs:
           retention-days: 90
   jetson-orin-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-alpine
     if: inputs.target_job == 'jetson-orin-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3267,30 +2499,18 @@ jobs:
           retention-days: 90
   jetson-orin-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-alpine
     if: inputs.target_job == 'jetson-orin-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3315,30 +2535,18 @@ jobs:
           retention-days: 90
   jetson-orin-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-debian
     if: inputs.target_job == 'jetson-orin-debian' || inputs.target_job == 'all' || inputs.target_job == 'jetson-orin-debian-golang' || inputs.target_job == 'jetson-orin-debian-node' || inputs.target_job == 'jetson-orin-debian-openjdk' || inputs.target_job == 'jetson-orin-debian-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3363,30 +2571,18 @@ jobs:
           retention-days: 90
   jetson-orin-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-debian
     if: inputs.target_job == 'jetson-orin-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3411,30 +2607,18 @@ jobs:
           retention-days: 90
   jetson-orin-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-debian
     if: inputs.target_job == 'jetson-orin-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3459,30 +2643,18 @@ jobs:
           retention-days: 90
   jetson-orin-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-debian
     if: inputs.target_job == 'jetson-orin-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3507,30 +2679,18 @@ jobs:
           retention-days: 90
   jetson-orin-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-debian
     if: inputs.target_job == 'jetson-orin-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3555,30 +2715,18 @@ jobs:
           retention-days: 90
   jetson-orin-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-fedora
     if: inputs.target_job == 'jetson-orin-fedora' || inputs.target_job == 'all' || inputs.target_job == 'jetson-orin-fedora-golang' || inputs.target_job == 'jetson-orin-fedora-node' || inputs.target_job == 'jetson-orin-fedora-openjdk' || inputs.target_job == 'jetson-orin-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3603,30 +2751,18 @@ jobs:
           retention-days: 90
   jetson-orin-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-fedora
     if: inputs.target_job == 'jetson-orin-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3651,30 +2787,18 @@ jobs:
           retention-days: 90
   jetson-orin-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-fedora
     if: inputs.target_job == 'jetson-orin-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3699,30 +2823,18 @@ jobs:
           retention-days: 90
   jetson-orin-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-fedora
     if: inputs.target_job == 'jetson-orin-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3747,30 +2859,18 @@ jobs:
           retention-days: 90
   jetson-orin-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-fedora
     if: inputs.target_job == 'jetson-orin-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3795,30 +2895,18 @@ jobs:
           retention-days: 90
   jetson-orin-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-ubuntu
     if: inputs.target_job == 'jetson-orin-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'jetson-orin-ubuntu-golang' || inputs.target_job == 'jetson-orin-ubuntu-node' || inputs.target_job == 'jetson-orin-ubuntu-openjdk' || inputs.target_job == 'jetson-orin-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3843,30 +2931,18 @@ jobs:
           retention-days: 90
   jetson-orin-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-ubuntu
     if: inputs.target_job == 'jetson-orin-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3891,30 +2967,18 @@ jobs:
           retention-days: 90
   jetson-orin-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-ubuntu
     if: inputs.target_job == 'jetson-orin-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3939,30 +3003,18 @@ jobs:
           retention-days: 90
   jetson-orin-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-ubuntu
     if: inputs.target_job == 'jetson-orin-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3987,30 +3039,18 @@ jobs:
           retention-days: 90
   jetson-orin-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-orin-ubuntu
     if: inputs.target_job == 'jetson-orin-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-orin-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4035,30 +3075,18 @@ jobs:
           retention-days: 90
   jetson-nano-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-alpine
     if: inputs.target_job == 'jetson-nano-alpine' || inputs.target_job == 'all' || inputs.target_job == 'jetson-nano-alpine-golang' || inputs.target_job == 'jetson-nano-alpine-node' || inputs.target_job == 'jetson-nano-alpine-openjdk' || inputs.target_job == 'jetson-nano-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4083,30 +3111,18 @@ jobs:
           retention-days: 90
   jetson-nano-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-alpine
     if: inputs.target_job == 'jetson-nano-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4131,30 +3147,18 @@ jobs:
           retention-days: 90
   jetson-nano-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-alpine
     if: inputs.target_job == 'jetson-nano-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4179,30 +3183,18 @@ jobs:
           retention-days: 90
   jetson-nano-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-alpine
     if: inputs.target_job == 'jetson-nano-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4227,30 +3219,18 @@ jobs:
           retention-days: 90
   jetson-nano-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-alpine
     if: inputs.target_job == 'jetson-nano-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4275,30 +3255,18 @@ jobs:
           retention-days: 90
   jetson-nano-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-debian
     if: inputs.target_job == 'jetson-nano-debian' || inputs.target_job == 'all' || inputs.target_job == 'jetson-nano-debian-golang' || inputs.target_job == 'jetson-nano-debian-node' || inputs.target_job == 'jetson-nano-debian-openjdk' || inputs.target_job == 'jetson-nano-debian-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4323,30 +3291,18 @@ jobs:
           retention-days: 90
   jetson-nano-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-debian
     if: inputs.target_job == 'jetson-nano-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4371,30 +3327,18 @@ jobs:
           retention-days: 90
   jetson-nano-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-debian
     if: inputs.target_job == 'jetson-nano-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4419,30 +3363,18 @@ jobs:
           retention-days: 90
   jetson-nano-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-debian
     if: inputs.target_job == 'jetson-nano-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4467,30 +3399,18 @@ jobs:
           retention-days: 90
   jetson-nano-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-debian
     if: inputs.target_job == 'jetson-nano-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4515,30 +3435,18 @@ jobs:
           retention-days: 90
   jetson-nano-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-fedora
     if: inputs.target_job == 'jetson-nano-fedora' || inputs.target_job == 'all' || inputs.target_job == 'jetson-nano-fedora-golang' || inputs.target_job == 'jetson-nano-fedora-node' || inputs.target_job == 'jetson-nano-fedora-openjdk' || inputs.target_job == 'jetson-nano-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4563,30 +3471,18 @@ jobs:
           retention-days: 90
   jetson-nano-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-fedora
     if: inputs.target_job == 'jetson-nano-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4611,30 +3507,18 @@ jobs:
           retention-days: 90
   jetson-nano-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-fedora
     if: inputs.target_job == 'jetson-nano-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4659,30 +3543,18 @@ jobs:
           retention-days: 90
   jetson-nano-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-fedora
     if: inputs.target_job == 'jetson-nano-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4707,30 +3579,18 @@ jobs:
           retention-days: 90
   jetson-nano-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-fedora
     if: inputs.target_job == 'jetson-nano-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4755,30 +3615,18 @@ jobs:
           retention-days: 90
   jetson-nano-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-ubuntu
     if: inputs.target_job == 'jetson-nano-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'jetson-nano-ubuntu-golang' || inputs.target_job == 'jetson-nano-ubuntu-node' || inputs.target_job == 'jetson-nano-ubuntu-openjdk' || inputs.target_job == 'jetson-nano-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4803,30 +3651,18 @@ jobs:
           retention-days: 90
   jetson-nano-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-ubuntu
     if: inputs.target_job == 'jetson-nano-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4851,30 +3687,18 @@ jobs:
           retention-days: 90
   jetson-nano-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-ubuntu
     if: inputs.target_job == 'jetson-nano-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4899,30 +3723,18 @@ jobs:
           retention-days: 90
   jetson-nano-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-ubuntu
     if: inputs.target_job == 'jetson-nano-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4947,30 +3759,18 @@ jobs:
           retention-days: 90
   jetson-nano-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-nano-ubuntu
     if: inputs.target_job == 'jetson-nano-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-nano-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -4995,30 +3795,18 @@ jobs:
           retention-days: 90
   jetson-tx2-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-alpine
     if: inputs.target_job == 'jetson-tx2-alpine' || inputs.target_job == 'all' || inputs.target_job == 'jetson-tx2-alpine-golang' || inputs.target_job == 'jetson-tx2-alpine-node' || inputs.target_job == 'jetson-tx2-alpine-openjdk' || inputs.target_job == 'jetson-tx2-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5043,30 +3831,18 @@ jobs:
           retention-days: 90
   jetson-tx2-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-alpine
     if: inputs.target_job == 'jetson-tx2-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5091,30 +3867,18 @@ jobs:
           retention-days: 90
   jetson-tx2-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-alpine
     if: inputs.target_job == 'jetson-tx2-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5139,30 +3903,18 @@ jobs:
           retention-days: 90
   jetson-tx2-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-alpine
     if: inputs.target_job == 'jetson-tx2-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5187,30 +3939,18 @@ jobs:
           retention-days: 90
   jetson-tx2-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-alpine
     if: inputs.target_job == 'jetson-tx2-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5235,30 +3975,18 @@ jobs:
           retention-days: 90
   jetson-tx2-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-debian
     if: inputs.target_job == 'jetson-tx2-debian' || inputs.target_job == 'all' || inputs.target_job == 'jetson-tx2-debian-golang' || inputs.target_job == 'jetson-tx2-debian-node' || inputs.target_job == 'jetson-tx2-debian-openjdk' || inputs.target_job == 'jetson-tx2-debian-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5283,30 +4011,18 @@ jobs:
           retention-days: 90
   jetson-tx2-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-debian
     if: inputs.target_job == 'jetson-tx2-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5331,30 +4047,18 @@ jobs:
           retention-days: 90
   jetson-tx2-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-debian
     if: inputs.target_job == 'jetson-tx2-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5379,30 +4083,18 @@ jobs:
           retention-days: 90
   jetson-tx2-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-debian
     if: inputs.target_job == 'jetson-tx2-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5427,30 +4119,18 @@ jobs:
           retention-days: 90
   jetson-tx2-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-debian
     if: inputs.target_job == 'jetson-tx2-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5475,30 +4155,18 @@ jobs:
           retention-days: 90
   jetson-tx2-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-fedora
     if: inputs.target_job == 'jetson-tx2-fedora' || inputs.target_job == 'all' || inputs.target_job == 'jetson-tx2-fedora-golang' || inputs.target_job == 'jetson-tx2-fedora-node' || inputs.target_job == 'jetson-tx2-fedora-openjdk' || inputs.target_job == 'jetson-tx2-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5523,30 +4191,18 @@ jobs:
           retention-days: 90
   jetson-tx2-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-fedora
     if: inputs.target_job == 'jetson-tx2-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5571,30 +4227,18 @@ jobs:
           retention-days: 90
   jetson-tx2-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-fedora
     if: inputs.target_job == 'jetson-tx2-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5619,30 +4263,18 @@ jobs:
           retention-days: 90
   jetson-tx2-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-fedora
     if: inputs.target_job == 'jetson-tx2-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5667,30 +4299,18 @@ jobs:
           retention-days: 90
   jetson-tx2-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-fedora
     if: inputs.target_job == 'jetson-tx2-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5715,30 +4335,18 @@ jobs:
           retention-days: 90
   jetson-tx2-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-ubuntu
     if: inputs.target_job == 'jetson-tx2-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'jetson-tx2-ubuntu-golang' || inputs.target_job == 'jetson-tx2-ubuntu-node' || inputs.target_job == 'jetson-tx2-ubuntu-openjdk' || inputs.target_job == 'jetson-tx2-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5763,30 +4371,18 @@ jobs:
           retention-days: 90
   jetson-tx2-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-ubuntu
     if: inputs.target_job == 'jetson-tx2-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5811,30 +4407,18 @@ jobs:
           retention-days: 90
   jetson-tx2-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-ubuntu
     if: inputs.target_job == 'jetson-tx2-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5859,30 +4443,18 @@ jobs:
           retention-days: 90
   jetson-tx2-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-ubuntu
     if: inputs.target_job == 'jetson-tx2-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5907,30 +4479,18 @@ jobs:
           retention-days: 90
   jetson-tx2-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-tx2-ubuntu
     if: inputs.target_job == 'jetson-tx2-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-tx2-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -5955,30 +4515,18 @@ jobs:
           retention-days: 90
   jetson-xavier-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-alpine
     if: inputs.target_job == 'jetson-xavier-alpine' || inputs.target_job == 'all' || inputs.target_job == 'jetson-xavier-alpine-golang' || inputs.target_job == 'jetson-xavier-alpine-node' || inputs.target_job == 'jetson-xavier-alpine-openjdk' || inputs.target_job == 'jetson-xavier-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6003,30 +4551,18 @@ jobs:
           retention-days: 90
   jetson-xavier-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-alpine
     if: inputs.target_job == 'jetson-xavier-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6051,30 +4587,18 @@ jobs:
           retention-days: 90
   jetson-xavier-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-alpine
     if: inputs.target_job == 'jetson-xavier-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6099,30 +4623,18 @@ jobs:
           retention-days: 90
   jetson-xavier-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-alpine
     if: inputs.target_job == 'jetson-xavier-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6147,30 +4659,18 @@ jobs:
           retention-days: 90
   jetson-xavier-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-alpine
     if: inputs.target_job == 'jetson-xavier-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6195,30 +4695,18 @@ jobs:
           retention-days: 90
   jetson-xavier-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-debian
     if: inputs.target_job == 'jetson-xavier-debian' || inputs.target_job == 'all' || inputs.target_job == 'jetson-xavier-debian-golang' || inputs.target_job == 'jetson-xavier-debian-node' || inputs.target_job == 'jetson-xavier-debian-openjdk' || inputs.target_job == 'jetson-xavier-debian-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6243,30 +4731,18 @@ jobs:
           retention-days: 90
   jetson-xavier-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-debian
     if: inputs.target_job == 'jetson-xavier-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6291,30 +4767,18 @@ jobs:
           retention-days: 90
   jetson-xavier-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-debian
     if: inputs.target_job == 'jetson-xavier-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6339,30 +4803,18 @@ jobs:
           retention-days: 90
   jetson-xavier-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-debian
     if: inputs.target_job == 'jetson-xavier-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6387,30 +4839,18 @@ jobs:
           retention-days: 90
   jetson-xavier-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-debian
     if: inputs.target_job == 'jetson-xavier-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6435,30 +4875,18 @@ jobs:
           retention-days: 90
   jetson-xavier-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-fedora
     if: inputs.target_job == 'jetson-xavier-fedora' || inputs.target_job == 'all' || inputs.target_job == 'jetson-xavier-fedora-golang' || inputs.target_job == 'jetson-xavier-fedora-node' || inputs.target_job == 'jetson-xavier-fedora-openjdk' || inputs.target_job == 'jetson-xavier-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6483,30 +4911,18 @@ jobs:
           retention-days: 90
   jetson-xavier-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-fedora
     if: inputs.target_job == 'jetson-xavier-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6531,30 +4947,18 @@ jobs:
           retention-days: 90
   jetson-xavier-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-fedora
     if: inputs.target_job == 'jetson-xavier-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6579,30 +4983,18 @@ jobs:
           retention-days: 90
   jetson-xavier-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-fedora
     if: inputs.target_job == 'jetson-xavier-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6627,30 +5019,18 @@ jobs:
           retention-days: 90
   jetson-xavier-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-fedora
     if: inputs.target_job == 'jetson-xavier-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6675,30 +5055,18 @@ jobs:
           retention-days: 90
   jetson-xavier-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-ubuntu
     if: inputs.target_job == 'jetson-xavier-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'jetson-xavier-ubuntu-golang' || inputs.target_job == 'jetson-xavier-ubuntu-node' || inputs.target_job == 'jetson-xavier-ubuntu-openjdk' || inputs.target_job == 'jetson-xavier-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6723,30 +5091,18 @@ jobs:
           retention-days: 90
   jetson-xavier-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-ubuntu
     if: inputs.target_job == 'jetson-xavier-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6771,30 +5127,18 @@ jobs:
           retention-days: 90
   jetson-xavier-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-ubuntu
     if: inputs.target_job == 'jetson-xavier-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6819,30 +5163,18 @@ jobs:
           retention-days: 90
   jetson-xavier-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-ubuntu
     if: inputs.target_job == 'jetson-xavier-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6867,30 +5199,18 @@ jobs:
           retention-days: 90
   jetson-xavier-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - jetson-xavier-ubuntu
     if: inputs.target_job == 'jetson-xavier-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'jetson-xavier-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6915,30 +5235,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-alpine
     if: inputs.target_job == 'raspberrypi-aarch64-alpine' || inputs.target_job == 'all' || inputs.target_job == 'raspberrypi-aarch64-alpine-golang' || inputs.target_job == 'raspberrypi-aarch64-alpine-node' || inputs.target_job == 'raspberrypi-aarch64-alpine-openjdk' || inputs.target_job == 'raspberrypi-aarch64-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -6963,30 +5271,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-alpine
     if: inputs.target_job == 'raspberrypi-aarch64-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7011,30 +5307,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-alpine
     if: inputs.target_job == 'raspberrypi-aarch64-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7059,30 +5343,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-alpine
     if: inputs.target_job == 'raspberrypi-aarch64-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7107,30 +5379,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-alpine
     if: inputs.target_job == 'raspberrypi-aarch64-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-alpine' || inputs.target_job == 'aarch64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7155,30 +5415,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-debian
     if: inputs.target_job == 'raspberrypi-aarch64-debian' || inputs.target_job == 'all' || inputs.target_job == 'raspberrypi-aarch64-debian-golang' || inputs.target_job == 'raspberrypi-aarch64-debian-node' || inputs.target_job == 'raspberrypi-aarch64-debian-openjdk' || inputs.target_job == 'raspberrypi-aarch64-debian-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7203,30 +5451,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-debian
     if: inputs.target_job == 'raspberrypi-aarch64-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7251,30 +5487,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-debian
     if: inputs.target_job == 'raspberrypi-aarch64-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7299,30 +5523,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-debian
     if: inputs.target_job == 'raspberrypi-aarch64-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7347,30 +5559,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-debian
     if: inputs.target_job == 'raspberrypi-aarch64-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-debian' || inputs.target_job == 'aarch64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7395,30 +5595,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-fedora
     if: inputs.target_job == 'raspberrypi-aarch64-fedora' || inputs.target_job == 'all' || inputs.target_job == 'raspberrypi-aarch64-fedora-golang' || inputs.target_job == 'raspberrypi-aarch64-fedora-node' || inputs.target_job == 'raspberrypi-aarch64-fedora-openjdk' || inputs.target_job == 'raspberrypi-aarch64-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7443,30 +5631,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-fedora
     if: inputs.target_job == 'raspberrypi-aarch64-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7491,30 +5667,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-fedora
     if: inputs.target_job == 'raspberrypi-aarch64-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7539,30 +5703,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-fedora
     if: inputs.target_job == 'raspberrypi-aarch64-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7587,30 +5739,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-fedora
     if: inputs.target_job == 'raspberrypi-aarch64-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-fedora' || inputs.target_job == 'aarch64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7635,30 +5775,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - aarch64-ubuntu
     if: inputs.target_job == 'raspberrypi-aarch64-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'raspberrypi-aarch64-ubuntu-golang' || inputs.target_job == 'raspberrypi-aarch64-ubuntu-node' || inputs.target_job == 'raspberrypi-aarch64-ubuntu-openjdk' || inputs.target_job == 'raspberrypi-aarch64-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7683,30 +5811,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-ubuntu
     if: inputs.target_job == 'raspberrypi-aarch64-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7731,30 +5847,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-ubuntu
     if: inputs.target_job == 'raspberrypi-aarch64-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7779,30 +5883,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-ubuntu
     if: inputs.target_job == 'raspberrypi-aarch64-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -7827,30 +5919,18 @@ jobs:
           retention-days: 90
   raspberrypi-aarch64-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-aarch64-ubuntu
     if: inputs.target_job == 'raspberrypi-aarch64-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-aarch64-ubuntu' || inputs.target_job == 'aarch64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV

--- a/.github/workflows/bashbrew-amd64.yml
+++ b/.github/workflows/bashbrew-amd64.yml
@@ -105,29 +105,17 @@ concurrency:
 jobs:
   amd64-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'amd64-alpine' || inputs.target_job == 'all' || inputs.target_job == 'amd64-alpine-golang' || inputs.target_job == 'amd64-alpine-node' || inputs.target_job == 'amd64-alpine-openjdk' || inputs.target_job == 'amd64-alpine-python' || inputs.target_job == 'generic-amd64-alpine' || inputs.target_job == 'up-board-alpine'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -152,30 +140,18 @@ jobs:
           retention-days: 90
   amd64-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-alpine
     if: inputs.target_job == 'amd64-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -200,30 +176,18 @@ jobs:
           retention-days: 90
   amd64-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-alpine
     if: inputs.target_job == 'amd64-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -248,30 +212,18 @@ jobs:
           retention-days: 90
   amd64-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-alpine
     if: inputs.target_job == 'amd64-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -296,30 +248,18 @@ jobs:
           retention-days: 90
   amd64-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-alpine
     if: inputs.target_job == 'amd64-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -344,29 +284,17 @@ jobs:
           retention-days: 90
   amd64-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'amd64-debian' || inputs.target_job == 'all' || inputs.target_job == 'amd64-debian-dotnet' || inputs.target_job == 'amd64-debian-golang' || inputs.target_job == 'amd64-debian-node' || inputs.target_job == 'amd64-debian-openjdk' || inputs.target_job == 'amd64-debian-python' || inputs.target_job == 'generic-amd64-debian' || inputs.target_job == 'up-board-debian'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -391,30 +319,18 @@ jobs:
           retention-days: 90
   amd64-debian-dotnet:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-debian
     if: inputs.target_job == 'amd64-debian-dotnet' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -439,30 +355,18 @@ jobs:
           retention-days: 90
   amd64-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-debian
     if: inputs.target_job == 'amd64-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -487,30 +391,18 @@ jobs:
           retention-days: 90
   amd64-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-debian
     if: inputs.target_job == 'amd64-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -535,30 +427,18 @@ jobs:
           retention-days: 90
   amd64-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-debian
     if: inputs.target_job == 'amd64-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -583,30 +463,18 @@ jobs:
           retention-days: 90
   amd64-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-debian
     if: inputs.target_job == 'amd64-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -631,29 +499,17 @@ jobs:
           retention-days: 90
   amd64-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'amd64-fedora' || inputs.target_job == 'all' || inputs.target_job == 'amd64-fedora-golang' || inputs.target_job == 'amd64-fedora-node' || inputs.target_job == 'amd64-fedora-openjdk' || inputs.target_job == 'amd64-fedora-python' || inputs.target_job == 'generic-amd64-fedora' || inputs.target_job == 'up-board-fedora'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -678,30 +534,18 @@ jobs:
           retention-days: 90
   amd64-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-fedora
     if: inputs.target_job == 'amd64-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -726,30 +570,18 @@ jobs:
           retention-days: 90
   amd64-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-fedora
     if: inputs.target_job == 'amd64-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -774,30 +606,18 @@ jobs:
           retention-days: 90
   amd64-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-fedora
     if: inputs.target_job == 'amd64-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -822,30 +642,18 @@ jobs:
           retention-days: 90
   amd64-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-fedora
     if: inputs.target_job == 'amd64-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -870,29 +678,17 @@ jobs:
           retention-days: 90
   amd64-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'amd64-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'amd64-ubuntu-dotnet' || inputs.target_job == 'amd64-ubuntu-golang' || inputs.target_job == 'amd64-ubuntu-node' || inputs.target_job == 'amd64-ubuntu-openjdk' || inputs.target_job == 'amd64-ubuntu-python' || inputs.target_job == 'generic-amd64-ubuntu' || inputs.target_job == 'up-board-ubuntu'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -917,30 +713,18 @@ jobs:
           retention-days: 90
   amd64-ubuntu-dotnet:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-ubuntu
     if: inputs.target_job == 'amd64-ubuntu-dotnet' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -965,30 +749,18 @@ jobs:
           retention-days: 90
   amd64-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-ubuntu
     if: inputs.target_job == 'amd64-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1013,30 +785,18 @@ jobs:
           retention-days: 90
   amd64-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-ubuntu
     if: inputs.target_job == 'amd64-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1061,30 +821,18 @@ jobs:
           retention-days: 90
   amd64-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-ubuntu
     if: inputs.target_job == 'amd64-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1109,30 +857,18 @@ jobs:
           retention-days: 90
   amd64-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-ubuntu
     if: inputs.target_job == 'amd64-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1157,30 +893,18 @@ jobs:
           retention-days: 90
   generic-amd64-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-alpine
     if: inputs.target_job == 'generic-amd64-alpine' || inputs.target_job == 'all' || inputs.target_job == 'generic-amd64-alpine-golang' || inputs.target_job == 'generic-amd64-alpine-node' || inputs.target_job == 'generic-amd64-alpine-openjdk' || inputs.target_job == 'generic-amd64-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1205,30 +929,18 @@ jobs:
           retention-days: 90
   generic-amd64-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-alpine
     if: inputs.target_job == 'generic-amd64-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-alpine' || inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1253,30 +965,18 @@ jobs:
           retention-days: 90
   generic-amd64-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-alpine
     if: inputs.target_job == 'generic-amd64-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-alpine' || inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1301,30 +1001,18 @@ jobs:
           retention-days: 90
   generic-amd64-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-alpine
     if: inputs.target_job == 'generic-amd64-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-alpine' || inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1349,30 +1037,18 @@ jobs:
           retention-days: 90
   generic-amd64-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-alpine
     if: inputs.target_job == 'generic-amd64-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-alpine' || inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1397,30 +1073,18 @@ jobs:
           retention-days: 90
   generic-amd64-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-debian
     if: inputs.target_job == 'generic-amd64-debian' || inputs.target_job == 'all' || inputs.target_job == 'generic-amd64-debian-dotnet' || inputs.target_job == 'generic-amd64-debian-golang' || inputs.target_job == 'generic-amd64-debian-node' || inputs.target_job == 'generic-amd64-debian-openjdk' || inputs.target_job == 'generic-amd64-debian-python' || (inputs.include_dependents && (inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1445,30 +1109,18 @@ jobs:
           retention-days: 90
   generic-amd64-debian-dotnet:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-debian
     if: inputs.target_job == 'generic-amd64-debian-dotnet' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-debian' || inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1493,30 +1145,18 @@ jobs:
           retention-days: 90
   generic-amd64-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-debian
     if: inputs.target_job == 'generic-amd64-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-debian' || inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1541,30 +1181,18 @@ jobs:
           retention-days: 90
   generic-amd64-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-debian
     if: inputs.target_job == 'generic-amd64-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-debian' || inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1589,30 +1217,18 @@ jobs:
           retention-days: 90
   generic-amd64-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-debian
     if: inputs.target_job == 'generic-amd64-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-debian' || inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1637,30 +1253,18 @@ jobs:
           retention-days: 90
   generic-amd64-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-debian
     if: inputs.target_job == 'generic-amd64-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-debian' || inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1685,30 +1289,18 @@ jobs:
           retention-days: 90
   generic-amd64-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-fedora
     if: inputs.target_job == 'generic-amd64-fedora' || inputs.target_job == 'all' || inputs.target_job == 'generic-amd64-fedora-golang' || inputs.target_job == 'generic-amd64-fedora-node' || inputs.target_job == 'generic-amd64-fedora-openjdk' || inputs.target_job == 'generic-amd64-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1733,30 +1325,18 @@ jobs:
           retention-days: 90
   generic-amd64-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-fedora
     if: inputs.target_job == 'generic-amd64-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-fedora' || inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1781,30 +1361,18 @@ jobs:
           retention-days: 90
   generic-amd64-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-fedora
     if: inputs.target_job == 'generic-amd64-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-fedora' || inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1829,30 +1397,18 @@ jobs:
           retention-days: 90
   generic-amd64-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-fedora
     if: inputs.target_job == 'generic-amd64-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-fedora' || inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1877,30 +1433,18 @@ jobs:
           retention-days: 90
   generic-amd64-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-fedora
     if: inputs.target_job == 'generic-amd64-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-fedora' || inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1925,30 +1469,18 @@ jobs:
           retention-days: 90
   generic-amd64-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-ubuntu
     if: inputs.target_job == 'generic-amd64-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'generic-amd64-ubuntu-dotnet' || inputs.target_job == 'generic-amd64-ubuntu-golang' || inputs.target_job == 'generic-amd64-ubuntu-node' || inputs.target_job == 'generic-amd64-ubuntu-openjdk' || inputs.target_job == 'generic-amd64-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1973,30 +1505,18 @@ jobs:
           retention-days: 90
   generic-amd64-ubuntu-dotnet:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-ubuntu
     if: inputs.target_job == 'generic-amd64-ubuntu-dotnet' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-ubuntu' || inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2021,30 +1541,18 @@ jobs:
           retention-days: 90
   generic-amd64-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-ubuntu
     if: inputs.target_job == 'generic-amd64-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-ubuntu' || inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2069,30 +1577,18 @@ jobs:
           retention-days: 90
   generic-amd64-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-ubuntu
     if: inputs.target_job == 'generic-amd64-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-ubuntu' || inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2117,30 +1613,18 @@ jobs:
           retention-days: 90
   generic-amd64-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-ubuntu
     if: inputs.target_job == 'generic-amd64-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-ubuntu' || inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2165,30 +1649,18 @@ jobs:
           retention-days: 90
   generic-amd64-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-amd64-ubuntu
     if: inputs.target_job == 'generic-amd64-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-amd64-ubuntu' || inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2213,30 +1685,18 @@ jobs:
           retention-days: 90
   up-board-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-alpine
     if: inputs.target_job == 'up-board-alpine' || inputs.target_job == 'all' || inputs.target_job == 'up-board-alpine-golang' || inputs.target_job == 'up-board-alpine-node' || inputs.target_job == 'up-board-alpine-openjdk' || inputs.target_job == 'up-board-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2261,30 +1721,18 @@ jobs:
           retention-days: 90
   up-board-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-alpine
     if: inputs.target_job == 'up-board-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-alpine' || inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2309,30 +1757,18 @@ jobs:
           retention-days: 90
   up-board-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-alpine
     if: inputs.target_job == 'up-board-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-alpine' || inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2357,30 +1793,18 @@ jobs:
           retention-days: 90
   up-board-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-alpine
     if: inputs.target_job == 'up-board-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-alpine' || inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2405,30 +1829,18 @@ jobs:
           retention-days: 90
   up-board-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-alpine
     if: inputs.target_job == 'up-board-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-alpine' || inputs.target_job == 'amd64-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2453,30 +1865,18 @@ jobs:
           retention-days: 90
   up-board-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-debian
     if: inputs.target_job == 'up-board-debian' || inputs.target_job == 'all' || inputs.target_job == 'up-board-debian-dotnet' || inputs.target_job == 'up-board-debian-golang' || inputs.target_job == 'up-board-debian-node' || inputs.target_job == 'up-board-debian-openjdk' || inputs.target_job == 'up-board-debian-python' || (inputs.include_dependents && (inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2501,30 +1901,18 @@ jobs:
           retention-days: 90
   up-board-debian-dotnet:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-debian
     if: inputs.target_job == 'up-board-debian-dotnet' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-debian' || inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2549,30 +1937,18 @@ jobs:
           retention-days: 90
   up-board-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-debian
     if: inputs.target_job == 'up-board-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-debian' || inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2597,30 +1973,18 @@ jobs:
           retention-days: 90
   up-board-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-debian
     if: inputs.target_job == 'up-board-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-debian' || inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2645,30 +2009,18 @@ jobs:
           retention-days: 90
   up-board-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-debian
     if: inputs.target_job == 'up-board-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-debian' || inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2693,30 +2045,18 @@ jobs:
           retention-days: 90
   up-board-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-debian
     if: inputs.target_job == 'up-board-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-debian' || inputs.target_job == 'amd64-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2741,30 +2081,18 @@ jobs:
           retention-days: 90
   up-board-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-fedora
     if: inputs.target_job == 'up-board-fedora' || inputs.target_job == 'all' || inputs.target_job == 'up-board-fedora-golang' || inputs.target_job == 'up-board-fedora-node' || inputs.target_job == 'up-board-fedora-openjdk' || inputs.target_job == 'up-board-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2789,30 +2117,18 @@ jobs:
           retention-days: 90
   up-board-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-fedora
     if: inputs.target_job == 'up-board-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-fedora' || inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2837,30 +2153,18 @@ jobs:
           retention-days: 90
   up-board-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-fedora
     if: inputs.target_job == 'up-board-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-fedora' || inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2885,30 +2189,18 @@ jobs:
           retention-days: 90
   up-board-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-fedora
     if: inputs.target_job == 'up-board-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-fedora' || inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2933,30 +2225,18 @@ jobs:
           retention-days: 90
   up-board-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-fedora
     if: inputs.target_job == 'up-board-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-fedora' || inputs.target_job == 'amd64-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2981,30 +2261,18 @@ jobs:
           retention-days: 90
   up-board-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - amd64-ubuntu
     if: inputs.target_job == 'up-board-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'up-board-ubuntu-dotnet' || inputs.target_job == 'up-board-ubuntu-golang' || inputs.target_job == 'up-board-ubuntu-node' || inputs.target_job == 'up-board-ubuntu-openjdk' || inputs.target_job == 'up-board-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3029,30 +2297,18 @@ jobs:
           retention-days: 90
   up-board-ubuntu-dotnet:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-ubuntu
     if: inputs.target_job == 'up-board-ubuntu-dotnet' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-ubuntu' || inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3077,30 +2333,18 @@ jobs:
           retention-days: 90
   up-board-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-ubuntu
     if: inputs.target_job == 'up-board-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-ubuntu' || inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3125,30 +2369,18 @@ jobs:
           retention-days: 90
   up-board-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-ubuntu
     if: inputs.target_job == 'up-board-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-ubuntu' || inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3173,30 +2405,18 @@ jobs:
           retention-days: 90
   up-board-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-ubuntu
     if: inputs.target_job == 'up-board-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-ubuntu' || inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3221,30 +2441,18 @@ jobs:
           retention-days: 90
   up-board-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - up-board-ubuntu
     if: inputs.target_job == 'up-board-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'up-board-ubuntu' || inputs.target_job == 'amd64-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV

--- a/.github/workflows/bashbrew-armv7hf.yml
+++ b/.github/workflows/bashbrew-armv7hf.yml
@@ -119,29 +119,17 @@ concurrency:
 jobs:
   armv7hf-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'armv7hf-alpine' || inputs.target_job == 'all' || inputs.target_job == 'armv7hf-alpine-golang' || inputs.target_job == 'armv7hf-alpine-node' || inputs.target_job == 'armv7hf-alpine-openjdk' || inputs.target_job == 'armv7hf-alpine-python' || inputs.target_job == 'beaglebone-alpine' || inputs.target_job == 'generic-armv7hf-alpine' || inputs.target_job == 'raspberrypi-armv7hf-alpine'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -166,30 +154,18 @@ jobs:
           retention-days: 90
   armv7hf-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-alpine
     if: inputs.target_job == 'armv7hf-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -214,30 +190,18 @@ jobs:
           retention-days: 90
   armv7hf-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-alpine
     if: inputs.target_job == 'armv7hf-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -262,30 +226,18 @@ jobs:
           retention-days: 90
   armv7hf-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-alpine
     if: inputs.target_job == 'armv7hf-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -310,30 +262,18 @@ jobs:
           retention-days: 90
   armv7hf-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-alpine
     if: inputs.target_job == 'armv7hf-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -358,29 +298,17 @@ jobs:
           retention-days: 90
   armv7hf-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'armv7hf-debian' || inputs.target_job == 'all' || inputs.target_job == 'armv7hf-debian-golang' || inputs.target_job == 'armv7hf-debian-node' || inputs.target_job == 'armv7hf-debian-openjdk' || inputs.target_job == 'armv7hf-debian-python' || inputs.target_job == 'beaglebone-debian' || inputs.target_job == 'generic-armv7hf-debian' || inputs.target_job == 'raspberrypi-armv7hf-debian'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -405,30 +333,18 @@ jobs:
           retention-days: 90
   armv7hf-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-debian
     if: inputs.target_job == 'armv7hf-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -453,30 +369,18 @@ jobs:
           retention-days: 90
   armv7hf-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-debian
     if: inputs.target_job == 'armv7hf-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -501,30 +405,18 @@ jobs:
           retention-days: 90
   armv7hf-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-debian
     if: inputs.target_job == 'armv7hf-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -549,30 +441,18 @@ jobs:
           retention-days: 90
   armv7hf-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-debian
     if: inputs.target_job == 'armv7hf-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -597,29 +477,17 @@ jobs:
           retention-days: 90
   armv7hf-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'armv7hf-fedora' || inputs.target_job == 'all' || inputs.target_job == 'armv7hf-fedora-golang' || inputs.target_job == 'armv7hf-fedora-node' || inputs.target_job == 'armv7hf-fedora-openjdk' || inputs.target_job == 'armv7hf-fedora-python' || inputs.target_job == 'beaglebone-fedora' || inputs.target_job == 'generic-armv7hf-fedora' || inputs.target_job == 'raspberrypi-armv7hf-fedora'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -644,30 +512,18 @@ jobs:
           retention-days: 90
   armv7hf-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-fedora
     if: inputs.target_job == 'armv7hf-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -692,30 +548,18 @@ jobs:
           retention-days: 90
   armv7hf-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-fedora
     if: inputs.target_job == 'armv7hf-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -740,30 +584,18 @@ jobs:
           retention-days: 90
   armv7hf-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-fedora
     if: inputs.target_job == 'armv7hf-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -788,30 +620,18 @@ jobs:
           retention-days: 90
   armv7hf-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-fedora
     if: inputs.target_job == 'armv7hf-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -836,29 +656,17 @@ jobs:
           retention-days: 90
   armv7hf-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'armv7hf-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'armv7hf-ubuntu-golang' || inputs.target_job == 'armv7hf-ubuntu-node' || inputs.target_job == 'armv7hf-ubuntu-openjdk' || inputs.target_job == 'armv7hf-ubuntu-python' || inputs.target_job == 'beaglebone-ubuntu' || inputs.target_job == 'generic-armv7hf-ubuntu' || inputs.target_job == 'raspberrypi-armv7hf-ubuntu'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -883,30 +691,18 @@ jobs:
           retention-days: 90
   armv7hf-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-ubuntu
     if: inputs.target_job == 'armv7hf-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -931,30 +727,18 @@ jobs:
           retention-days: 90
   armv7hf-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-ubuntu
     if: inputs.target_job == 'armv7hf-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -979,30 +763,18 @@ jobs:
           retention-days: 90
   armv7hf-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-ubuntu
     if: inputs.target_job == 'armv7hf-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1027,30 +799,18 @@ jobs:
           retention-days: 90
   armv7hf-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-ubuntu
     if: inputs.target_job == 'armv7hf-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1075,30 +835,18 @@ jobs:
           retention-days: 90
   beaglebone-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-alpine
     if: inputs.target_job == 'beaglebone-alpine' || inputs.target_job == 'all' || inputs.target_job == 'beaglebone-alpine-golang' || inputs.target_job == 'beaglebone-alpine-node' || inputs.target_job == 'beaglebone-alpine-openjdk' || inputs.target_job == 'beaglebone-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1123,30 +871,18 @@ jobs:
           retention-days: 90
   beaglebone-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-alpine
     if: inputs.target_job == 'beaglebone-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1171,30 +907,18 @@ jobs:
           retention-days: 90
   beaglebone-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-alpine
     if: inputs.target_job == 'beaglebone-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1219,30 +943,18 @@ jobs:
           retention-days: 90
   beaglebone-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-alpine
     if: inputs.target_job == 'beaglebone-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1267,30 +979,18 @@ jobs:
           retention-days: 90
   beaglebone-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-alpine
     if: inputs.target_job == 'beaglebone-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1315,30 +1015,18 @@ jobs:
           retention-days: 90
   beaglebone-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-debian
     if: inputs.target_job == 'beaglebone-debian' || inputs.target_job == 'all' || inputs.target_job == 'beaglebone-debian-golang' || inputs.target_job == 'beaglebone-debian-node' || inputs.target_job == 'beaglebone-debian-openjdk' || inputs.target_job == 'beaglebone-debian-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1363,30 +1051,18 @@ jobs:
           retention-days: 90
   beaglebone-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-debian
     if: inputs.target_job == 'beaglebone-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1411,30 +1087,18 @@ jobs:
           retention-days: 90
   beaglebone-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-debian
     if: inputs.target_job == 'beaglebone-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1459,30 +1123,18 @@ jobs:
           retention-days: 90
   beaglebone-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-debian
     if: inputs.target_job == 'beaglebone-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1507,30 +1159,18 @@ jobs:
           retention-days: 90
   beaglebone-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-debian
     if: inputs.target_job == 'beaglebone-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1555,30 +1195,18 @@ jobs:
           retention-days: 90
   beaglebone-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-fedora
     if: inputs.target_job == 'beaglebone-fedora' || inputs.target_job == 'all' || inputs.target_job == 'beaglebone-fedora-golang' || inputs.target_job == 'beaglebone-fedora-node' || inputs.target_job == 'beaglebone-fedora-openjdk' || inputs.target_job == 'beaglebone-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1603,30 +1231,18 @@ jobs:
           retention-days: 90
   beaglebone-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-fedora
     if: inputs.target_job == 'beaglebone-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1651,30 +1267,18 @@ jobs:
           retention-days: 90
   beaglebone-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-fedora
     if: inputs.target_job == 'beaglebone-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1699,30 +1303,18 @@ jobs:
           retention-days: 90
   beaglebone-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-fedora
     if: inputs.target_job == 'beaglebone-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1747,30 +1339,18 @@ jobs:
           retention-days: 90
   beaglebone-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-fedora
     if: inputs.target_job == 'beaglebone-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1795,30 +1375,18 @@ jobs:
           retention-days: 90
   beaglebone-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-ubuntu
     if: inputs.target_job == 'beaglebone-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'beaglebone-ubuntu-golang' || inputs.target_job == 'beaglebone-ubuntu-node' || inputs.target_job == 'beaglebone-ubuntu-openjdk' || inputs.target_job == 'beaglebone-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1843,30 +1411,18 @@ jobs:
           retention-days: 90
   beaglebone-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-ubuntu
     if: inputs.target_job == 'beaglebone-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1891,30 +1447,18 @@ jobs:
           retention-days: 90
   beaglebone-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-ubuntu
     if: inputs.target_job == 'beaglebone-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1939,30 +1483,18 @@ jobs:
           retention-days: 90
   beaglebone-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-ubuntu
     if: inputs.target_job == 'beaglebone-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1987,30 +1519,18 @@ jobs:
           retention-days: 90
   beaglebone-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - beaglebone-ubuntu
     if: inputs.target_job == 'beaglebone-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'beaglebone-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2035,30 +1555,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-alpine
     if: inputs.target_job == 'generic-armv7hf-alpine' || inputs.target_job == 'all' || inputs.target_job == 'generic-armv7hf-alpine-golang' || inputs.target_job == 'generic-armv7hf-alpine-node' || inputs.target_job == 'generic-armv7hf-alpine-openjdk' || inputs.target_job == 'generic-armv7hf-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2083,30 +1591,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-alpine
     if: inputs.target_job == 'generic-armv7hf-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2131,30 +1627,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-alpine
     if: inputs.target_job == 'generic-armv7hf-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2179,30 +1663,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-alpine
     if: inputs.target_job == 'generic-armv7hf-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2227,30 +1699,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-alpine
     if: inputs.target_job == 'generic-armv7hf-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2275,30 +1735,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-debian
     if: inputs.target_job == 'generic-armv7hf-debian' || inputs.target_job == 'all' || inputs.target_job == 'generic-armv7hf-debian-golang' || inputs.target_job == 'generic-armv7hf-debian-node' || inputs.target_job == 'generic-armv7hf-debian-openjdk' || inputs.target_job == 'generic-armv7hf-debian-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2323,30 +1771,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-debian
     if: inputs.target_job == 'generic-armv7hf-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2371,30 +1807,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-debian
     if: inputs.target_job == 'generic-armv7hf-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2419,30 +1843,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-debian
     if: inputs.target_job == 'generic-armv7hf-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2467,30 +1879,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-debian
     if: inputs.target_job == 'generic-armv7hf-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2515,30 +1915,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-fedora
     if: inputs.target_job == 'generic-armv7hf-fedora' || inputs.target_job == 'all' || inputs.target_job == 'generic-armv7hf-fedora-golang' || inputs.target_job == 'generic-armv7hf-fedora-node' || inputs.target_job == 'generic-armv7hf-fedora-openjdk' || inputs.target_job == 'generic-armv7hf-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2563,30 +1951,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-fedora
     if: inputs.target_job == 'generic-armv7hf-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2611,30 +1987,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-fedora
     if: inputs.target_job == 'generic-armv7hf-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2659,30 +2023,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-fedora
     if: inputs.target_job == 'generic-armv7hf-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2707,30 +2059,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-fedora
     if: inputs.target_job == 'generic-armv7hf-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2755,30 +2095,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-ubuntu
     if: inputs.target_job == 'generic-armv7hf-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'generic-armv7hf-ubuntu-golang' || inputs.target_job == 'generic-armv7hf-ubuntu-node' || inputs.target_job == 'generic-armv7hf-ubuntu-openjdk' || inputs.target_job == 'generic-armv7hf-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2803,30 +2131,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-ubuntu
     if: inputs.target_job == 'generic-armv7hf-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2851,30 +2167,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-ubuntu
     if: inputs.target_job == 'generic-armv7hf-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2899,30 +2203,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-ubuntu
     if: inputs.target_job == 'generic-armv7hf-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2947,30 +2239,18 @@ jobs:
           retention-days: 90
   generic-armv7hf-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-armv7hf-ubuntu
     if: inputs.target_job == 'generic-armv7hf-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-armv7hf-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -2995,30 +2275,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-alpine
     if: inputs.target_job == 'raspberrypi-armv7hf-alpine' || inputs.target_job == 'all' || inputs.target_job == 'raspberrypi-armv7hf-alpine-golang' || inputs.target_job == 'raspberrypi-armv7hf-alpine-node' || inputs.target_job == 'raspberrypi-armv7hf-alpine-openjdk' || inputs.target_job == 'raspberrypi-armv7hf-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3043,30 +2311,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-alpine
     if: inputs.target_job == 'raspberrypi-armv7hf-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3091,30 +2347,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-alpine
     if: inputs.target_job == 'raspberrypi-armv7hf-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3139,30 +2383,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-alpine
     if: inputs.target_job == 'raspberrypi-armv7hf-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3187,30 +2419,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-alpine
     if: inputs.target_job == 'raspberrypi-armv7hf-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-alpine' || inputs.target_job == 'armv7hf-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3235,30 +2455,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-debian
     if: inputs.target_job == 'raspberrypi-armv7hf-debian' || inputs.target_job == 'all' || inputs.target_job == 'raspberrypi-armv7hf-debian-golang' || inputs.target_job == 'raspberrypi-armv7hf-debian-node' || inputs.target_job == 'raspberrypi-armv7hf-debian-openjdk' || inputs.target_job == 'raspberrypi-armv7hf-debian-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3283,30 +2491,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-debian
     if: inputs.target_job == 'raspberrypi-armv7hf-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3331,30 +2527,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-debian
     if: inputs.target_job == 'raspberrypi-armv7hf-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3379,30 +2563,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-debian
     if: inputs.target_job == 'raspberrypi-armv7hf-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3427,30 +2599,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-debian
     if: inputs.target_job == 'raspberrypi-armv7hf-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-debian' || inputs.target_job == 'armv7hf-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3475,30 +2635,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-fedora:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-fedora
     if: inputs.target_job == 'raspberrypi-armv7hf-fedora' || inputs.target_job == 'all' || inputs.target_job == 'raspberrypi-armv7hf-fedora-golang' || inputs.target_job == 'raspberrypi-armv7hf-fedora-node' || inputs.target_job == 'raspberrypi-armv7hf-fedora-openjdk' || inputs.target_job == 'raspberrypi-armv7hf-fedora-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3523,30 +2671,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-fedora-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-fedora
     if: inputs.target_job == 'raspberrypi-armv7hf-fedora-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3571,30 +2707,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-fedora-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-fedora
     if: inputs.target_job == 'raspberrypi-armv7hf-fedora-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3619,30 +2743,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-fedora-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-fedora
     if: inputs.target_job == 'raspberrypi-armv7hf-fedora-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3667,30 +2779,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-fedora-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-fedora
     if: inputs.target_job == 'raspberrypi-armv7hf-fedora-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-fedora' || inputs.target_job == 'armv7hf-fedora'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3715,30 +2815,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - armv7hf-ubuntu
     if: inputs.target_job == 'raspberrypi-armv7hf-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'raspberrypi-armv7hf-ubuntu-golang' || inputs.target_job == 'raspberrypi-armv7hf-ubuntu-node' || inputs.target_job == 'raspberrypi-armv7hf-ubuntu-openjdk' || inputs.target_job == 'raspberrypi-armv7hf-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3763,30 +2851,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-ubuntu
     if: inputs.target_job == 'raspberrypi-armv7hf-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3811,30 +2887,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-ubuntu
     if: inputs.target_job == 'raspberrypi-armv7hf-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3859,30 +2923,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-ubuntu
     if: inputs.target_job == 'raspberrypi-armv7hf-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -3907,30 +2959,18 @@ jobs:
           retention-days: 90
   raspberrypi-armv7hf-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberrypi-armv7hf-ubuntu
     if: inputs.target_job == 'raspberrypi-armv7hf-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberrypi-armv7hf-ubuntu' || inputs.target_job == 'armv7hf-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV

--- a/.github/workflows/bashbrew-i386.yml
+++ b/.github/workflows/bashbrew-i386.yml
@@ -69,29 +69,17 @@ concurrency:
 jobs:
   i386-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'i386-alpine' || inputs.target_job == 'all' || inputs.target_job == 'i386-alpine-golang' || inputs.target_job == 'i386-alpine-node' || inputs.target_job == 'i386-alpine-openjdk' || inputs.target_job == 'i386-alpine-python' || inputs.target_job == 'generic-x86-alpine'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -116,30 +104,18 @@ jobs:
           retention-days: 90
   i386-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-alpine
     if: inputs.target_job == 'i386-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -164,30 +140,18 @@ jobs:
           retention-days: 90
   i386-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-alpine
     if: inputs.target_job == 'i386-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -212,30 +176,18 @@ jobs:
           retention-days: 90
   i386-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-alpine
     if: inputs.target_job == 'i386-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -260,30 +212,18 @@ jobs:
           retention-days: 90
   i386-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-alpine
     if: inputs.target_job == 'i386-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -308,29 +248,17 @@ jobs:
           retention-days: 90
   i386-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'i386-debian' || inputs.target_job == 'all' || inputs.target_job == 'i386-debian-golang' || inputs.target_job == 'i386-debian-node' || inputs.target_job == 'i386-debian-openjdk' || inputs.target_job == 'i386-debian-python' || inputs.target_job == 'generic-x86-debian'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -355,30 +283,18 @@ jobs:
           retention-days: 90
   i386-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-debian
     if: inputs.target_job == 'i386-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -403,30 +319,18 @@ jobs:
           retention-days: 90
   i386-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-debian
     if: inputs.target_job == 'i386-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -451,30 +355,18 @@ jobs:
           retention-days: 90
   i386-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-debian
     if: inputs.target_job == 'i386-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -499,30 +391,18 @@ jobs:
           retention-days: 90
   i386-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-debian
     if: inputs.target_job == 'i386-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -547,29 +427,17 @@ jobs:
           retention-days: 90
   i386-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'i386-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'i386-ubuntu-golang' || inputs.target_job == 'i386-ubuntu-node' || inputs.target_job == 'i386-ubuntu-openjdk' || inputs.target_job == 'i386-ubuntu-python' || inputs.target_job == 'generic-x86-ubuntu'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -594,30 +462,18 @@ jobs:
           retention-days: 90
   i386-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-ubuntu
     if: inputs.target_job == 'i386-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -642,30 +498,18 @@ jobs:
           retention-days: 90
   i386-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-ubuntu
     if: inputs.target_job == 'i386-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -690,30 +534,18 @@ jobs:
           retention-days: 90
   i386-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-ubuntu
     if: inputs.target_job == 'i386-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -738,30 +570,18 @@ jobs:
           retention-days: 90
   i386-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-ubuntu
     if: inputs.target_job == 'i386-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'i386-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -786,30 +606,18 @@ jobs:
           retention-days: 90
   generic-x86-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-alpine
     if: inputs.target_job == 'generic-x86-alpine' || inputs.target_job == 'all' || inputs.target_job == 'generic-x86-alpine-golang' || inputs.target_job == 'generic-x86-alpine-node' || inputs.target_job == 'generic-x86-alpine-openjdk' || inputs.target_job == 'generic-x86-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'i386-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -834,30 +642,18 @@ jobs:
           retention-days: 90
   generic-x86-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-alpine
     if: inputs.target_job == 'generic-x86-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-alpine' || inputs.target_job == 'i386-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -882,30 +678,18 @@ jobs:
           retention-days: 90
   generic-x86-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-alpine
     if: inputs.target_job == 'generic-x86-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-alpine' || inputs.target_job == 'i386-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -930,30 +714,18 @@ jobs:
           retention-days: 90
   generic-x86-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-alpine
     if: inputs.target_job == 'generic-x86-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-alpine' || inputs.target_job == 'i386-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -978,30 +750,18 @@ jobs:
           retention-days: 90
   generic-x86-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-alpine
     if: inputs.target_job == 'generic-x86-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-alpine' || inputs.target_job == 'i386-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1026,30 +786,18 @@ jobs:
           retention-days: 90
   generic-x86-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-debian
     if: inputs.target_job == 'generic-x86-debian' || inputs.target_job == 'all' || inputs.target_job == 'generic-x86-debian-golang' || inputs.target_job == 'generic-x86-debian-node' || inputs.target_job == 'generic-x86-debian-openjdk' || inputs.target_job == 'generic-x86-debian-python' || (inputs.include_dependents && (inputs.target_job == 'i386-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1074,30 +822,18 @@ jobs:
           retention-days: 90
   generic-x86-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-debian
     if: inputs.target_job == 'generic-x86-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-debian' || inputs.target_job == 'i386-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1122,30 +858,18 @@ jobs:
           retention-days: 90
   generic-x86-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-debian
     if: inputs.target_job == 'generic-x86-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-debian' || inputs.target_job == 'i386-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1170,30 +894,18 @@ jobs:
           retention-days: 90
   generic-x86-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-debian
     if: inputs.target_job == 'generic-x86-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-debian' || inputs.target_job == 'i386-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1218,30 +930,18 @@ jobs:
           retention-days: 90
   generic-x86-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-debian
     if: inputs.target_job == 'generic-x86-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-debian' || inputs.target_job == 'i386-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1266,30 +966,18 @@ jobs:
           retention-days: 90
   generic-x86-ubuntu:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - i386-ubuntu
     if: inputs.target_job == 'generic-x86-ubuntu' || inputs.target_job == 'all' || inputs.target_job == 'generic-x86-ubuntu-golang' || inputs.target_job == 'generic-x86-ubuntu-node' || inputs.target_job == 'generic-x86-ubuntu-openjdk' || inputs.target_job == 'generic-x86-ubuntu-python' || (inputs.include_dependents && (inputs.target_job == 'i386-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1314,30 +1002,18 @@ jobs:
           retention-days: 90
   generic-x86-ubuntu-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-ubuntu
     if: inputs.target_job == 'generic-x86-ubuntu-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-ubuntu' || inputs.target_job == 'i386-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1362,30 +1038,18 @@ jobs:
           retention-days: 90
   generic-x86-ubuntu-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-ubuntu
     if: inputs.target_job == 'generic-x86-ubuntu-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-ubuntu' || inputs.target_job == 'i386-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1410,30 +1074,18 @@ jobs:
           retention-days: 90
   generic-x86-ubuntu-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-ubuntu
     if: inputs.target_job == 'generic-x86-ubuntu-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-ubuntu' || inputs.target_job == 'i386-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -1458,30 +1110,18 @@ jobs:
           retention-days: 90
   generic-x86-ubuntu-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - generic-x86-ubuntu
     if: inputs.target_job == 'generic-x86-ubuntu-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'generic-x86-ubuntu' || inputs.target_job == 'i386-ubuntu'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV

--- a/.github/workflows/bashbrew-rpi.yml
+++ b/.github/workflows/bashbrew-rpi.yml
@@ -59,29 +59,17 @@ concurrency:
 jobs:
   rpi-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'rpi-alpine' || inputs.target_job == 'all' || inputs.target_job == 'rpi-alpine-golang' || inputs.target_job == 'rpi-alpine-node' || inputs.target_job == 'rpi-alpine-openjdk' || inputs.target_job == 'rpi-alpine-python' || inputs.target_job == 'raspberry-pi-alpine'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -106,30 +94,18 @@ jobs:
           retention-days: 90
   rpi-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - rpi-alpine
     if: inputs.target_job == 'rpi-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'rpi-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -154,30 +130,18 @@ jobs:
           retention-days: 90
   rpi-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - rpi-alpine
     if: inputs.target_job == 'rpi-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'rpi-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -202,30 +166,18 @@ jobs:
           retention-days: 90
   rpi-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - rpi-alpine
     if: inputs.target_job == 'rpi-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'rpi-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -250,30 +202,18 @@ jobs:
           retention-days: 90
   rpi-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - rpi-alpine
     if: inputs.target_job == 'rpi-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'rpi-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -298,29 +238,17 @@ jobs:
           retention-days: 90
   rpi-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs: []
     if: inputs.target_job == 'rpi-debian' || inputs.target_job == 'all' || inputs.target_job == 'rpi-debian-golang' || inputs.target_job == 'rpi-debian-node' || inputs.target_job == 'rpi-debian-openjdk' || inputs.target_job == 'rpi-debian-python' || inputs.target_job == 'raspberry-pi-debian'
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -345,30 +273,18 @@ jobs:
           retention-days: 90
   rpi-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - rpi-debian
     if: inputs.target_job == 'rpi-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'rpi-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -393,30 +309,18 @@ jobs:
           retention-days: 90
   rpi-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - rpi-debian
     if: inputs.target_job == 'rpi-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'rpi-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -441,30 +345,18 @@ jobs:
           retention-days: 90
   rpi-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - rpi-debian
     if: inputs.target_job == 'rpi-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'rpi-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -489,30 +381,18 @@ jobs:
           retention-days: 90
   rpi-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - rpi-debian
     if: inputs.target_job == 'rpi-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'rpi-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -537,30 +417,18 @@ jobs:
           retention-days: 90
   raspberry-pi-alpine:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - rpi-alpine
     if: inputs.target_job == 'raspberry-pi-alpine' || inputs.target_job == 'all' || inputs.target_job == 'raspberry-pi-alpine-golang' || inputs.target_job == 'raspberry-pi-alpine-node' || inputs.target_job == 'raspberry-pi-alpine-openjdk' || inputs.target_job == 'raspberry-pi-alpine-python' || (inputs.include_dependents && (inputs.target_job == 'rpi-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -585,30 +453,18 @@ jobs:
           retention-days: 90
   raspberry-pi-alpine-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberry-pi-alpine
     if: inputs.target_job == 'raspberry-pi-alpine-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberry-pi-alpine' || inputs.target_job == 'rpi-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -633,30 +489,18 @@ jobs:
           retention-days: 90
   raspberry-pi-alpine-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberry-pi-alpine
     if: inputs.target_job == 'raspberry-pi-alpine-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberry-pi-alpine' || inputs.target_job == 'rpi-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -681,30 +525,18 @@ jobs:
           retention-days: 90
   raspberry-pi-alpine-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberry-pi-alpine
     if: inputs.target_job == 'raspberry-pi-alpine-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberry-pi-alpine' || inputs.target_job == 'rpi-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -729,30 +561,18 @@ jobs:
           retention-days: 90
   raspberry-pi-alpine-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberry-pi-alpine
     if: inputs.target_job == 'raspberry-pi-alpine-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberry-pi-alpine' || inputs.target_job == 'rpi-alpine'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -777,30 +597,18 @@ jobs:
           retention-days: 90
   raspberry-pi-debian:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - rpi-debian
     if: inputs.target_job == 'raspberry-pi-debian' || inputs.target_job == 'all' || inputs.target_job == 'raspberry-pi-debian-golang' || inputs.target_job == 'raspberry-pi-debian-node' || inputs.target_job == 'raspberry-pi-debian-openjdk' || inputs.target_job == 'raspberry-pi-debian-python' || (inputs.include_dependents && (inputs.target_job == 'rpi-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -825,30 +633,18 @@ jobs:
           retention-days: 90
   raspberry-pi-debian-golang:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberry-pi-debian
     if: inputs.target_job == 'raspberry-pi-debian-golang' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberry-pi-debian' || inputs.target_job == 'rpi-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -873,30 +669,18 @@ jobs:
           retention-days: 90
   raspberry-pi-debian-node:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberry-pi-debian
     if: inputs.target_job == 'raspberry-pi-debian-node' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberry-pi-debian' || inputs.target_job == 'rpi-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -921,30 +705,18 @@ jobs:
           retention-days: 90
   raspberry-pi-debian-openjdk:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberry-pi-debian
     if: inputs.target_job == 'raspberry-pi-debian-openjdk' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberry-pi-debian' || inputs.target_job == 'rpi-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV
@@ -969,30 +741,18 @@ jobs:
           retention-days: 90
   raspberry-pi-debian-python:
     runs-on:
-      - ubuntu-latest
+      - self-hosted
+      - base-images
+      - X64
     timeout-minutes: 480
     needs:
       - raspberry-pi-debian
     if: inputs.target_job == 'raspberry-pi-debian-python' || inputs.target_job == 'all' || (inputs.include_dependents && (inputs.target_job == 'raspberry-pi-debian' || inputs.target_job == 'rpi-debian'))
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
-        with:
-          root-reserve-mb: 40960
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-          image: tonistiigi/binfmt:qemu-v6.2.0
       - name: Disable build
         if: ${{ inputs.no_build }}
         run: echo "EXTRA_OPTS=$EXTRA_OPTS --no-build" >> $GITHUB_ENV


### PR DESCRIPTION
Require the special label "base-images" to avoid bottlenecking the all self-hosted runners in use by other projects.

At the moment this effectively limits base images to 8 concurrent builds (4 per server * 2) until we provision more runners with this tag.

Change-type: patch