### PR TITLE
Revert "Autogenerate workflow files on pre-commit"

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm run all-workflows
-git add .github/workflows/bashbrew-*.yml

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "all-lib": "node scripts/generate-stackbrew-library.js all",
     "all-dockerhub": "node scripts/generate-dockerhub-description.js all",
     "all-workflows": "node scripts/generate-workflows.js all",
-    "test": "time -p npm run os-arch && time -p npm run os-arch-lib",
-    "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\""
+    "test": "time -p npm run os-arch && time -p npm run os-arch-lib"
   },
   "author": "Resin Inc. <hello@resin.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
This reverts commit 89afe302fa99497322d91a90373ee734e1c1279f.

The pre-commit is being called during automated workflows and fails to commit the resulting files due to lack of permissions.

Change-type: patch