### PR TITLE
Add a schedule to trigger os-arch and stack-arch jobs

### DIFF
--- a/.github/workflows/all-bake.yml
+++ b/.github/workflows/all-bake.yml
@@ -1,0 +1,35 @@
+name: Bake all
+'on':
+  workflow_dispatch:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+  schedule:
+    # runs at 3:12 only on Saturdays
+    - cron: '12 3 * * 6'
+
+# Workflows below should be limited to one at a time
+# by the concurency group in the workflow templates.
+jobs:
+  bake-aarch64:
+    name: Bake aarch64
+    uses: ./.github/workflows/bake-aarch64.yml
+    secrets: inherit
+
+  bake-amd64:
+    name: Bake amd64
+    uses: ./.github/workflows/bake-amd64.yml
+    secrets: inherit
+
+  bake-armv7hf:
+    name: Bake armv7hf
+    uses: ./.github/workflows/bake-armv7hf.yml
+    secrets: inherit
+
+  bake-i386:
+    name: Bake i386
+    uses: ./.github/workflows/bake-i386.yml
+    secrets: inherit
+
+  bake-rpi:
+    name: Bake rpi
+    uses: ./.github/workflows/bake-rpi.yml
+    secrets: inherit

--- a/scripts/blueprints/workflows/os-arch.yaml
+++ b/scripts/blueprints/workflows/os-arch.yaml
@@ -13,21 +13,40 @@ output:
     "on":
       workflow_call:
         inputs:
+          # FIXME: no-push is not inherited by downstream workflows
           no-push:
             description: Do not push to DockerHub
+            required: false
+            type: boolean
+            default: false
+          cancel-in-progress:
+            description: Cancel in-progress bake workflows for all device-types
             required: false
             type: boolean
             default: false
       workflow_dispatch:
         inputs:
+          # FIXME: no-push is not inherited by downstream workflows
           no-push:
             description: Do not push to DockerHub
             required: false
             type: boolean
             default: false
+          cancel-in-progress:
+            description: Cancel in-progress bake workflows for all device-types
+            required: false
+            type: boolean
+            default: false
+    # A single workflow can generate hundreds of jobs once the matrixes are
+    # expanded, so we are limiting to a single concurrent bake workflow even if
+    # they are of different architectures and device types.
+    # As such, we will never cancel in-progress workflows unless a user forces it,
+    # and instead will queue the workflows behind the current one.
+    # This also means we don't have to be fancy with scheduling, as we can trust
+    # that only one workflow will ever be running at once.
     concurrency:
-      group: ${{ github.workflow }}
-      cancel-in-progress: true
+      group: bake
+      cancel-in-progress: ${{ inputs.cancel-in-progress == true }}
     jobs:
       prepare:
         name: Prepare {{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}
@@ -51,7 +70,7 @@ output:
       bake:
         name: Bake {{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}
         runs-on: ubuntu-latest
-        # timeout-minutes: 480
+        timeout-minutes: 240
         needs: prepare-{{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}
         env:
           LIBRARY: library/{{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}.json

--- a/scripts/blueprints/workflows/os-device.yaml
+++ b/scripts/blueprints/workflows/os-device.yaml
@@ -24,6 +24,11 @@ output:
             required: false
             type: boolean
             default: false
+          cancel-in-progress:
+            description: Cancel in-progress bake workflows for all device-types
+            required: false
+            type: boolean
+            default: false
       workflow_dispatch:
         inputs:
           no-push:
@@ -31,9 +36,21 @@ output:
             required: false
             type: boolean
             default: false
+          cancel-in-progress:
+            description: Cancel in-progress bake workflows for all device-types
+            required: false
+            type: boolean
+            default: false
+    # A single workflow can generate hundreds of jobs once the matrixes are
+    # expanded, so we are limiting to a single concurrent bake workflow even if
+    # they are of different architectures and device types.
+    # As such, we will never cancel in-progress workflows unless a user forces it,
+    # and instead will queue the workflows behind the current one.
+    # This also means we don't have to be fancy with scheduling, as we can trust
+    # that only one workflow will ever be running at once.
     concurrency:
-      group: ${{ github.workflow }}
-      cancel-in-progress: true
+      group: bake
+      cancel-in-progress: ${{ inputs.cancel-in-progress == true }}
     jobs:
       prepare:
         name: Prepare {{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}
@@ -57,7 +74,7 @@ output:
       bake:
         name: Bake {{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}
         runs-on: ubuntu-latest
-        # timeout-minutes: 480
+        timeout-minutes: 240
         needs: prepare-{{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}
         env:
           LIBRARY: library/{{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}.json

--- a/scripts/blueprints/workflows/stack-arch.yaml
+++ b/scripts/blueprints/workflows/stack-arch.yaml
@@ -14,21 +14,40 @@ output:
     "on":
       workflow_call:
         inputs:
+          # FIXME: no-push is not inherited by downstream workflows
           no-push:
             description: Do not push to DockerHub
+            required: false
+            type: boolean
+            default: false
+          cancel-in-progress:
+            description: Cancel in-progress bake workflows for all device-types
             required: false
             type: boolean
             default: false
       workflow_dispatch:
         inputs:
+          # FIXME: no-push is not inherited by downstream workflows
           no-push:
             description: Do not push to DockerHub
             required: false
             type: boolean
             default: false
+          cancel-in-progress:
+            description: Cancel in-progress bake workflows for all device-types
+            required: false
+            type: boolean
+            default: false
+    # A single workflow can generate hundreds of jobs once the matrixes are
+    # expanded, so we are limiting to a single concurrent bake workflow even if
+    # they are of different architectures and device types.
+    # As such, we will never cancel in-progress workflows unless a user forces it,
+    # and instead will queue the workflows behind the current one.
+    # This also means we don't have to be fancy with scheduling, as we can trust
+    # that only one workflow will ever be running at once.
     concurrency:
-      group: ${{ github.workflow }}
-      cancel-in-progress: true
+      group: bake
+      cancel-in-progress: ${{ inputs.cancel-in-progress == true }}
     jobs:
       prepare:
         name: Prepare {{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}
@@ -53,7 +72,7 @@ output:
       bake:
         name: Bake {{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}
         runs-on: ubuntu-latest
-        # timeout-minutes: 480
+        timeout-minutes: 240
         needs: prepare-{{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}
         env:
           LIBRARY: library/{{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}.json

--- a/scripts/blueprints/workflows/stack-device.yaml
+++ b/scripts/blueprints/workflows/stack-device.yaml
@@ -25,6 +25,11 @@ output:
             required: false
             type: boolean
             default: false
+          cancel-in-progress:
+            description: Cancel in-progress bake workflows for all device-types
+            required: false
+            type: boolean
+            default: false
       workflow_dispatch:
         inputs:
           no-push:
@@ -32,9 +37,21 @@ output:
             required: false
             type: boolean
             default: false
+          cancel-in-progress:
+            description: Cancel in-progress bake workflows for all device-types
+            required: false
+            type: boolean
+            default: false
+    # A single workflow can generate hundreds of jobs once the matrixes are
+    # expanded, so we are limiting to a single concurrent bake workflow even if
+    # they are of different architectures and device types.
+    # As such, we will never cancel in-progress workflows unless a user forces it,
+    # and instead will queue the workflows behind the current one.
+    # This also means we don't have to be fancy with scheduling, as we can trust
+    # that only one workflow will ever be running at once.
     concurrency:
-      group: ${{ github.workflow }}
-      cancel-in-progress: true
+      group: bake
+      cancel-in-progress: ${{ inputs.cancel-in-progress == true }}
     jobs:
       prepare:
         name: Prepare {{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}
@@ -59,7 +76,7 @@ output:
       bake:
         name: Bake {{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}
         runs-on: ubuntu-latest
-        # timeout-minutes: 480
+        timeout-minutes: 240
         needs: prepare-{{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}
         env:
           LIBRARY: library/{{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}.json


### PR DESCRIPTION
Use concurrency group settings to ensure that only
one bake workflow, no matter the device type or arch,
can be running at a single time. The rest will be queued
by default, with a manual option to cancel in-progress.

Since each workflow can generate 100s of jobs once
the matrices are expanded, we need this concurrency
limit to remain within the 500 concurrent runner
maximum allowed by our enterprise plan.