### PR TITLE
Allow the Bake all workflow to be triggered manually

### DIFF
--- a/.github/workflows/all-bake.yml
+++ b/.github/workflows/all-bake.yml
@@ -1,35 +1,38 @@
 name: Bake all
 'on':
   workflow_dispatch:
+    inputs:
+      cancel-in-progress:
+        description: Cancel in-progress bake workflows for all device-types and stacks
+        required: false
+        type: boolean
+        default: true
+      no-start:
+        description: Do not trigger any new bake workflows
+        required: false
+        type: boolean
+        default: false
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
   schedule:
-    # runs at 3:12 only on Saturdays
-    - cron: '12 3 * * 6'
+    # run at 01:11 on the 1st day of the month
+    - cron: '11 1 1 * *'
 
-# Workflows below should be limited to one at a time
-# by the concurency group in the workflow templates.
+# A single bake workflow can generate hundreds of jobs once the matrixes are
+# expanded, so they are limited the same concurrency group even though
+# they are of different architectures and device types.
+# Cancelling jobs in progress is destructive as the entire pipeline could
+# take days to complete, and a cancellation means jobs jobs at the end of
+# the queue never get run.
+concurrency:
+  group: bake
+  cancel-in-progress: ${{ inputs.cancel-in-progress == true }}
+
+# Downstream bake workflows are listening for 'Bake all' workflow_run completed events but
+# they will be skipped if the condition github.event.workflow_run.conclusion != 'success'.
 jobs:
-  bake-aarch64:
-    name: Bake aarch64
-    uses: ./.github/workflows/bake-aarch64.yml
-    secrets: inherit
-
-  bake-amd64:
-    name: Bake amd64
-    uses: ./.github/workflows/bake-amd64.yml
-    secrets: inherit
-
-  bake-armv7hf:
-    name: Bake armv7hf
-    uses: ./.github/workflows/bake-armv7hf.yml
-    secrets: inherit
-
-  bake-i386:
-    name: Bake i386
-    uses: ./.github/workflows/bake-i386.yml
-    secrets: inherit
-
-  bake-rpi:
-    name: Bake rpi
-    uses: ./.github/workflows/bake-rpi.yml
-    secrets: inherit
+  do-failure:
+    name: Do not trigger any new bake workflows
+    runs-on: ubuntu-latest
+    if: inputs.no-start == true
+    steps:
+      - run: exit 1

--- a/scripts/blueprints/workflows/os-arch.yaml
+++ b/scripts/blueprints/workflows/os-arch.yaml
@@ -11,19 +11,11 @@ output:
   template:
     name: Bake {{this.children.arch.sw.slug}}
     "on":
-      workflow_call:
-        inputs:
-          # FIXME: no-push is not inherited by downstream workflows
-          no-push:
-            description: Do not push to DockerHub
-            required: false
-            type: boolean
-            default: false
-          cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types
-            required: false
-            type: boolean
-            default: false
+      workflow_run:
+        workflows:
+          - Bake all
+        types:
+          - completed
       workflow_dispatch:
         inputs:
           # FIXME: no-push is not inherited by downstream workflows
@@ -33,17 +25,10 @@ output:
             type: boolean
             default: false
           cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types
+            description: Cancel in-progress bake workflows for all device-types and stacks
             required: false
             type: boolean
             default: false
-    # A single workflow can generate hundreds of jobs once the matrixes are
-    # expanded, so we are limiting to a single concurrent bake workflow even if
-    # they are of different architectures and device types.
-    # As such, we will never cancel in-progress workflows unless a user forces it,
-    # and instead will queue the workflows behind the current one.
-    # This also means we don't have to be fancy with scheduling, as we can trust
-    # that only one workflow will ever be running at once.
     concurrency:
       group: bake
       cancel-in-progress: ${{ inputs.cancel-in-progress == true }}
@@ -51,6 +36,7 @@ output:
       prepare:
         name: Prepare {{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}
         runs-on: ubuntu-latest
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         outputs:
           bake-targets: ${{ steps.bake-targets.outputs.matrix }}
         env:

--- a/scripts/blueprints/workflows/os-device.yaml
+++ b/scripts/blueprints/workflows/os-device.yaml
@@ -17,18 +17,6 @@ output:
           - Bake {{this.children.arch.sw.slug}}
         types:
           - completed
-      workflow_call:
-        inputs:
-          no-push:
-            description: Do not push to DockerHub
-            required: false
-            type: boolean
-            default: false
-          cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types
-            required: false
-            type: boolean
-            default: false
       workflow_dispatch:
         inputs:
           no-push:
@@ -37,17 +25,10 @@ output:
             type: boolean
             default: false
           cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types
+            description: Cancel in-progress bake workflows for all device-types and stacks
             required: false
             type: boolean
             default: false
-    # A single workflow can generate hundreds of jobs once the matrixes are
-    # expanded, so we are limiting to a single concurrent bake workflow even if
-    # they are of different architectures and device types.
-    # As such, we will never cancel in-progress workflows unless a user forces it,
-    # and instead will queue the workflows behind the current one.
-    # This also means we don't have to be fancy with scheduling, as we can trust
-    # that only one workflow will ever be running at once.
     concurrency:
       group: bake
       cancel-in-progress: ${{ inputs.cancel-in-progress == true }}

--- a/scripts/blueprints/workflows/stack-arch.yaml
+++ b/scripts/blueprints/workflows/stack-arch.yaml
@@ -12,19 +12,11 @@ output:
   template:
     name: Bake {{this.children.arch.sw.slug}}
     "on":
-      workflow_call:
-        inputs:
-          # FIXME: no-push is not inherited by downstream workflows
-          no-push:
-            description: Do not push to DockerHub
-            required: false
-            type: boolean
-            default: false
-          cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types
-            required: false
-            type: boolean
-            default: false
+      workflow_run:
+        workflows:
+          - Bake all
+        types:
+          - completed
       workflow_dispatch:
         inputs:
           # FIXME: no-push is not inherited by downstream workflows
@@ -34,17 +26,10 @@ output:
             type: boolean
             default: false
           cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types
+            description: Cancel in-progress bake workflows for all device-types and stacks
             required: false
             type: boolean
             default: false
-    # A single workflow can generate hundreds of jobs once the matrixes are
-    # expanded, so we are limiting to a single concurrent bake workflow even if
-    # they are of different architectures and device types.
-    # As such, we will never cancel in-progress workflows unless a user forces it,
-    # and instead will queue the workflows behind the current one.
-    # This also means we don't have to be fancy with scheduling, as we can trust
-    # that only one workflow will ever be running at once.
     concurrency:
       group: bake
       cancel-in-progress: ${{ inputs.cancel-in-progress == true }}
@@ -52,6 +37,7 @@ output:
       prepare:
         name: Prepare {{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}
         runs-on: ubuntu-latest
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         needs: bake-{{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}
         outputs:
           bake-targets: ${{ steps.bake-targets.outputs.matrix }}

--- a/scripts/blueprints/workflows/stack-device.yaml
+++ b/scripts/blueprints/workflows/stack-device.yaml
@@ -18,18 +18,6 @@ output:
           - Bake {{this.children.arch.sw.slug}}
         types:
           - completed
-      workflow_call:
-        inputs:
-          no-push:
-            description: Do not push to DockerHub
-            required: false
-            type: boolean
-            default: false
-          cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types
-            required: false
-            type: boolean
-            default: false
       workflow_dispatch:
         inputs:
           no-push:
@@ -38,17 +26,10 @@ output:
             type: boolean
             default: false
           cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types
+            description: Cancel in-progress bake workflows for all device-types and stacks
             required: false
             type: boolean
             default: false
-    # A single workflow can generate hundreds of jobs once the matrixes are
-    # expanded, so we are limiting to a single concurrent bake workflow even if
-    # they are of different architectures and device types.
-    # As such, we will never cancel in-progress workflows unless a user forces it,
-    # and instead will queue the workflows behind the current one.
-    # This also means we don't have to be fancy with scheduling, as we can trust
-    # that only one workflow will ever be running at once.
     concurrency:
       group: bake
       cancel-in-progress: ${{ inputs.cancel-in-progress == true }}


### PR DESCRIPTION
Use the workflow run event to trigger listening
jobs rather than calling them directly.

Use the same concurrency group for all bake workflows, allowing for cancellation of all jobs in progress without starting new ones.

Change-type: patch