### PR TITLE
Make cancel-in-progress an opt-in feature with clear explanation

### DIFF
--- a/.github/workflows/all-bake.yml
+++ b/.github/workflows/all-bake.yml
@@ -3,12 +3,7 @@ name: Bake all
   workflow_dispatch:
     inputs:
       cancel-in-progress:
-        description: Cancel in-progress bake workflows for all device-types and stacks
-        required: false
-        type: boolean
-        default: true
-      no-start:
-        description: Do not trigger any new bake workflows
+        description: Cancel all in-progress bake workflows and do not start any new ones
         required: false
         type: boolean
         default: false
@@ -20,9 +15,8 @@ name: Bake all
 # A single bake workflow can generate hundreds of jobs once the matrixes are
 # expanded, so they are limited the same concurrency group even though
 # they are of different architectures and device types.
-# Cancelling jobs in progress is destructive as the entire pipeline could
-# take days to complete, and a cancellation means jobs jobs at the end of
-# the queue never get run.
+# Do not cancel in-progress as we are expecting multiple bake workflows listening
+# for this event and we don't want them to cancel each other.
 concurrency:
   group: bake
   cancel-in-progress: ${{ inputs.cancel-in-progress == true }}
@@ -30,9 +24,9 @@ concurrency:
 # Downstream bake workflows are listening for 'Bake all' workflow_run completed events but
 # they will be skipped if the condition github.event.workflow_run.conclusion != 'success'.
 jobs:
-  do-failure:
-    name: Do not trigger any new bake workflows
+  do-success:
+    name: Return success
     runs-on: ubuntu-latest
-    if: inputs.no-start == true
+    if: ${{ inputs.cancel-in-progress != true }}
     steps:
-      - run: exit 1
+      - run: exit 0

--- a/scripts/blueprints/workflows/os-arch.yaml
+++ b/scripts/blueprints/workflows/os-arch.yaml
@@ -25,7 +25,7 @@ output:
             type: boolean
             default: false
           cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types and stacks
+            description: Cancel all in-progress bake workflows and only run this one
             required: false
             type: boolean
             default: false
@@ -36,7 +36,7 @@ output:
       prepare:
         name: Prepare {{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}
         runs-on: ubuntu-latest
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure') }}
         outputs:
           bake-targets: ${{ steps.bake-targets.outputs.matrix }}
         env:

--- a/scripts/blueprints/workflows/os-device.yaml
+++ b/scripts/blueprints/workflows/os-device.yaml
@@ -25,7 +25,7 @@ output:
             type: boolean
             default: false
           cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types and stacks
+            description: Cancel all in-progress bake workflows and only run this one
             required: false
             type: boolean
             default: false
@@ -36,6 +36,7 @@ output:
       prepare:
         name: Prepare {{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}
         runs-on: ubuntu-latest
+        if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure') }}
         outputs:
           bake-targets: ${{ steps.bake-targets.outputs.matrix }}
         env:

--- a/scripts/blueprints/workflows/stack-arch.yaml
+++ b/scripts/blueprints/workflows/stack-arch.yaml
@@ -26,7 +26,7 @@ output:
             type: boolean
             default: false
           cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types and stacks
+            description: Cancel all in-progress bake workflows and only run this one
             required: false
             type: boolean
             default: false
@@ -37,7 +37,6 @@ output:
       prepare:
         name: Prepare {{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}
         runs-on: ubuntu-latest
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         needs: bake-{{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}
         outputs:
           bake-targets: ${{ steps.bake-targets.outputs.matrix }}

--- a/scripts/blueprints/workflows/stack-device.yaml
+++ b/scripts/blueprints/workflows/stack-device.yaml
@@ -26,7 +26,7 @@ output:
             type: boolean
             default: false
           cancel-in-progress:
-            description: Cancel in-progress bake workflows for all device-types and stacks
+            description: Cancel all in-progress bake workflows and only run this one
             required: false
             type: boolean
             default: false


### PR DESCRIPTION
Make downstream workflows conditional on the triggering workflow returning success or failure, not skipped or cancelled.

Change-type: patch