### PR TITLE
Update short descriptions to mark balenalib base images as deprecated

### DIFF
--- a/scripts/blueprints/workflows/os-arch.yaml
+++ b/scripts/blueprints/workflows/os-arch.yaml
@@ -118,4 +118,4 @@ output:
               password: ${{ secrets.BALENAIMAGES_TOKEN }}
               repository: "balenalib/{{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}"
               readme-filepath: ./balena-base-images/docs/dockerhub/{{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}-full-description.md
-              short-description: "This image is part of the balena.io base image series for IoT devices."
+              short-description: "Deprecated: This image is no longer receiving updates."

--- a/scripts/blueprints/workflows/os-device.yaml
+++ b/scripts/blueprints/workflows/os-device.yaml
@@ -118,4 +118,4 @@ output:
               password: ${{ secrets.BALENAIMAGES_TOKEN }}
               repository: "balenalib/{{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}"
               readme-filepath: ./balena-base-images/docs/dockerhub/{{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}-full-description.md
-              short-description: "This image is part of the balena.io base image series for IoT devices."
+              short-description: "Deprecated: This image is no longer receiving updates."

--- a/scripts/blueprints/workflows/stack-arch.yaml
+++ b/scripts/blueprints/workflows/stack-arch.yaml
@@ -119,4 +119,4 @@ output:
               password: ${{ secrets.BALENAIMAGES_TOKEN }}
               repository: "balenalib/{{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}"
               readme-filepath: ./balena-base-images/docs/dockerhub/{{this.children.arch.sw.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}-full-description.md
-              short-description: "This image is part of the balena.io base image series for IoT devices."
+              short-description: "Deprecated: This image is no longer receiving updates."

--- a/scripts/blueprints/workflows/stack-device.yaml
+++ b/scripts/blueprints/workflows/stack-device.yaml
@@ -119,4 +119,4 @@ output:
               password: ${{ secrets.BALENAIMAGES_TOKEN }}
               repository: "balenalib/{{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}"
               readme-filepath: ./balena-base-images/docs/dockerhub/{{this.children.hw.device-type.slug}}-{{this.children.sw.os.slug}}-{{this.children.sw.stack.slug}}-full-description.md
-              short-description: "This image is part of the balena.io base image series for IoT devices."
+              short-description: "Deprecated: This image is no longer receiving updates."


### PR DESCRIPTION
Update the short description for Docker Hub to mark images as deprecated

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
